### PR TITLE
Add Linux Steam Proton support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 | --- | --- | --- |
 | **DLSS5-Swapper-Setup-2.1.1.exe** | 231 MB | Installer — shortcuts, clean uninstall |
 | **DLSS5-Swapper-2.1.1-portable.exe** | 231 MB | Single file, no installation |
+| **DLSS5-Swapper-2.1.1-x86_64.AppImage** | Linux | Portable Linux app — download from [Releases](../../releases) |
 
 Get either from the [**Releases**](../../releases) page. Windows 10/11 64-bit
 and an NVIDIA RTX card. Nothing else to install.
@@ -41,6 +42,18 @@ prefix. Launch the game once with a Proton compatibility tool selected before
 installing. Native Linux games are not supported because the DLSS 5 and ReShade
 payloads are Windows DLLs. The Vulkan Feeder route is not available on Linux;
 select a DirectX renderer for Proton games.
+
+To run the AppImage, make it executable and open it:
+
+```bash
+chmod +x DLSS5-Swapper-*-x86_64.AppImage
+./DLSS5-Swapper-*-x86_64.AppImage
+```
+
+> The Linux build needs the same bundled payload as the Windows release. A
+> preview built from this repository without `payload/` can test the interface
+> and Steam/Proton detection, but cannot install DLSS until that payload is
+> supplied.
 
 > Not code-signed, so SmartScreen shows *"Windows protected your PC"* the first
 > time. Click **More info → Run anyway**.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="../../releases/latest"><img src="https://img.shields.io/github/v/release/rakanki911/DLSS5-Swapper?style=flat-square&color=8fd400&label=release&cacheSeconds=300" alt="Release"></a>
   <a href="../../releases"><img src="https://img.shields.io/github/downloads/rakanki911/DLSS5-Swapper/total?style=flat-square&color=8fd400&label=downloads&cacheSeconds=300" alt="Downloads"></a>
-  <img src="https://img.shields.io/badge/platform-Windows%2010%2F11-8fd400?style=flat-square" alt="Windows">
+  <img src="https://img.shields.io/badge/platform-Windows%2010%2F11%20%7C%20Linux%20(Proton)-8fd400?style=flat-square" alt="Windows and Linux Proton">
   <img src="https://img.shields.io/badge/languages-38-8fd400?style=flat-square" alt="38 languages">
   <img src="https://img.shields.io/badge/licence-MIT-8fd400?style=flat-square" alt="MIT">
 </p>
@@ -31,6 +31,16 @@
 
 Get either from the [**Releases**](../../releases) page. Windows 10/11 64-bit
 and an NVIDIA RTX card. Nothing else to install.
+
+### Linux (Steam Play / Proton)
+
+Linux builds are available as AppImage and `.deb`. They support **Windows games
+run through Steam Proton**: Steam libraries are discovered from the standard
+Linux locations and ReShade Setup runs inside the game's existing Proton
+prefix. Launch the game once with a Proton compatibility tool selected before
+installing. Native Linux games are not supported because the DLSS 5 and ReShade
+payloads are Windows DLLs. The Vulkan Feeder route is not available on Linux;
+select a DirectX renderer for Proton games.
 
 > Not code-signed, so SmartScreen shows *"Windows protected your PC"* the first
 > time. Click **More info → Run anyway**.

--- a/main.js
+++ b/main.js
@@ -9,7 +9,8 @@ const { pathToFileURL } = require('url');
 const crypto = require('crypto');
 
 const { scanGame } = require('./src/core/scan.js');
-const { discover, folder, dedupe, isInside } = require('./src/library');
+const { discover, folder, dedupe, isInside, steam } = require('./src/library');
+const { contextForSteamGame, createSetupRunner } = require('./src/core/proton');
 const art = require('./src/steamart');
 const { applySwap, restore, backupRoot } = require('./src/core/apply.js');
 const { scanSource } = require('./src/core/scan.js');
@@ -758,6 +759,20 @@ ipcMain.handle('install', async (event, dir, exePath, requestedRoute, requestedA
   const route = availableRoutes.includes(requestedRoute) ? requestedRoute
     : (availableRoutes.includes(recommendedRoute) ? recommendedRoute : availableRoutes[0]);
 
+  // ReShade Setup is a Windows executable. On Linux, support Windows games
+  // launched with Steam Play by using their existing Proton prefix; native
+  // Linux games do not load the Windows DLSS/ReShade payload.
+  const protonGame = process.platform === 'linux'
+    ? steam().find((game) => path.resolve(game.dir) === path.resolve(dir))
+    : null;
+  const proton = contextForSteamGame(protonGame);
+  if (process.platform === 'linux' && !proton) {
+    return { ok: false, code: 'errProtonRequired', message: 'This installer supports Windows games launched through Steam Proton. Launch the game once with Proton, then try again.' };
+  }
+  if (process.platform === 'linux' && api === 'vulkan') {
+    return { ok: false, code: 'errLinuxVulkanUnsupported', message: 'The Vulkan Feeder route needs a host Vulkan layer and is not supported on Linux yet. Select a DirectX renderer in the game.' };
+  }
+
   const send = (e) => event.sender.send('job', e);
 
   // Switching between the native and synthetic Feeder contracts must be a
@@ -821,6 +836,7 @@ ipcMain.handle('install', async (event, dir, exePath, requestedRoute, requestedA
       emulator: target.emulator,
       source: p.source,
       reshadeSetup: p.reshadeSetup,
+      setupRunner: proton ? createSetupRunner(proton) : undefined,
       vulkanLayerTarget: path.join(app.getPath('userData'), 'reshade-vulkan'),
       installReShade: true,
       addMissingDlss: true,

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "test": "node --test --test-isolation=none --test-concurrency=1 test/*.test.js",
+    "test": "node --test --test-concurrency=1 test/*.test.js",
     "payload": "node scripts/collect-payload.js",
     "prebuild": "npm run payload",
     "build": "electron-builder --win",
+    "build:linux": "electron-builder --linux AppImage deb",
     "icon": "electron scripts/make-icon.js",
     "build:portable": "electron-builder --win portable"
   },
@@ -54,6 +55,13 @@
         "portable"
       ],
       "icon": "build/icon.ico"
+    },
+    "linux": {
+      "target": ["AppImage", "deb"],
+      "category": "Game",
+      "maintainer": "Rakan Alkhaldi",
+      "icon": "app_iocn.png",
+      "artifactName": "DLSS5-Swapper-${version}-${arch}.${ext}"
     },
     "compression": "maximum",
     "portable": {

--- a/src/core/proton.js
+++ b/src/core/proton.js
@@ -1,0 +1,51 @@
+'use strict';
+// Runs Windows-only helper programs (currently ReShade Setup) in the exact
+// Steam Play prefix used by a game.  Copying DLLs itself is ordinary Linux IO;
+// only the setup executable needs Proton.
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+function protonCandidates(steamRoot, prefix) {
+  const common = path.join(steamRoot, 'steamapps', 'common');
+  let names = [];
+  try { names = fs.readdirSync(common); } catch { return []; }
+  let configured = '';
+  try { configured = fs.readFileSync(path.join(path.dirname(prefix), 'config_info'), 'utf8').trim(); } catch {}
+  return names
+    .filter((name) => /^Proton(?:\s|\d|[-_])/i.test(name))
+    .sort((a, b) => Number(b.includes(configured)) - Number(a.includes(configured)))
+    .map((name) => path.join(common, name, 'proton'))
+    .filter((file) => fs.existsSync(file));
+}
+
+function contextForSteamGame(game) {
+  if (process.platform !== 'linux' || !game || !game.steamRoot || !game.protonPrefix) return null;
+  if (!fs.existsSync(game.protonPrefix)) return null;
+  const proton = protonCandidates(game.steamRoot, game.protonPrefix)[0];
+  return proton ? { proton, prefix: game.protonPrefix, steamRoot: game.steamRoot, appid: game.id } : null;
+}
+
+function createSetupRunner(context) {
+  return (setupExe, args, log) => new Promise((resolve) => {
+    log('runningSetup', { setup: path.basename(setupExe), args: args.slice(1).join(' ') });
+    const child = spawn(context.proton, ['run', setupExe, ...args], {
+      cwd: path.dirname(args[0]),
+      env: {
+        ...process.env,
+        WINEPREFIX: context.prefix,
+        STEAM_COMPAT_DATA_PATH: path.dirname(context.prefix),
+        STEAM_COMPAT_CLIENT_INSTALL_PATH: context.steamRoot,
+        STEAM_COMPAT_APP_ID: context.appid
+      }
+    });
+    let output = '';
+    child.stdout.on('data', (data) => { output += data.toString(); });
+    child.stderr.on('data', (data) => { output += data.toString(); });
+    child.on('error', (error) => resolve({ code: -1, output: error.message }));
+    child.on('close', (code) => resolve({ code, output: output.trim() }));
+    setTimeout(() => { try { child.kill(); } catch {} }, 120000);
+  });
+}
+
+module.exports = { protonCandidates, contextForSteamGame, createSetupRunner };

--- a/src/library.js
+++ b/src/library.js
@@ -3,6 +3,7 @@
 // Everything here is a read: no network, no accounts, nothing written back to
 // any launcher.
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
@@ -50,32 +51,57 @@ function steamPoster(steamRoot, appid) {
   return null;
 }
 
-function steam() {
-  const root = reg('HKCU\\Software\\Valve\\Steam', 'SteamPath');
-  if (!root) return [];
-  const base = root.replace(/\//g, '\\');
+function linuxSteamRoots(home = os.homedir(), env = process.env) {
+  // Steam has used both of these locations over time.  Do not resolve the
+  // ~/.steam/steam symlink: its path is also useful to portable installs.
+  const dataHome = env.XDG_DATA_HOME || path.join(home, '.local', 'share');
+  return [...new Set([
+    path.join(dataHome, 'Steam'),
+    path.join(home, '.steam', 'steam'),
+    // Flatpak keeps its Steam data outside XDG_DATA_HOME.
+    path.join(home, '.var', 'app', 'com.valvesoftware.Steam', 'data', 'Steam')
+  ])].filter((dir) => fs.existsSync(path.join(dir, 'steamapps')));
+}
 
-  const libraries = new Set([base]);
-  try {
-    const vdf = fs.readFileSync(path.join(base, 'steamapps', 'libraryfolders.vdf'), 'utf8');
-    for (const m of vdf.matchAll(/"path"\s+"([^"]+)"/g)) libraries.add(m[1].replace(/\\\\/g, '\\'));
-  } catch {}
+function steam(options = {}) {
+  const platform = options.platform || process.platform;
+  const roots = options.roots || (platform === 'linux'
+    ? linuxSteamRoots(options.home, options.env)
+    : [reg('HKCU\\Software\\Valve\\Steam', 'SteamPath')].filter(Boolean));
+  if (!roots.length) return [];
 
   const games = [];
-  for (const lib of libraries) {
-    const appsDir = path.join(lib, 'steamapps');
-    let files = [];
-    try { files = fs.readdirSync(appsDir).filter((f) => /^appmanifest_\d+\.acf$/.test(f)); } catch { continue; }
-    for (const f of files) {
-      let text;
-      try { text = fs.readFileSync(path.join(appsDir, f), 'utf8'); } catch { continue; }
-      const appid = kv(text, 'appid');
-      const installdir = kv(text, 'installdir');
-      const name = kv(text, 'name') || installdir;
-      if (!appid || !installdir || NOT_A_GAME.test(name)) continue;
-      const dir = path.join(appsDir, 'common', installdir);
-      if (!fs.existsSync(dir)) continue;
-      games.push({ launcher: 'Steam', id: appid, name, dir, poster: steamPoster(base, appid) });
+  for (const root of roots) {
+    const base = platform === 'win32' ? root.replace(/\//g, '\\') : root;
+
+    const libraries = new Set([base]);
+    try {
+      const vdf = fs.readFileSync(path.join(base, 'steamapps', 'libraryfolders.vdf'), 'utf8');
+      for (const m of vdf.matchAll(/"path"\s+"([^"]+)"/g)) libraries.add(m[1].replace(/\\\\/g, '\\'));
+    } catch {}
+
+    for (const lib of libraries) {
+      const appsDir = path.join(lib, 'steamapps');
+      let files = [];
+      try { files = fs.readdirSync(appsDir).filter((f) => /^appmanifest_\d+\.acf$/.test(f)); } catch { continue; }
+      for (const f of files) {
+        let text;
+        try { text = fs.readFileSync(path.join(appsDir, f), 'utf8'); } catch { continue; }
+        const appid = kv(text, 'appid');
+        const installdir = kv(text, 'installdir');
+        const name = kv(text, 'name') || installdir;
+        if (!appid || !installdir || NOT_A_GAME.test(name)) continue;
+        const dir = path.join(appsDir, 'common', installdir);
+        if (!fs.existsSync(dir)) continue;
+        games.push({
+          launcher: 'Steam', id: appid, name, dir, poster: steamPoster(base, appid),
+          steamRoot: base,
+          // A prefix only exists for titles launched through Steam Play. This
+          // metadata lets the installer run the Windows ReShade setup in the
+          // same Proton bottle as the game instead of invoking a host Wine.
+          protonPrefix: platform === 'linux' ? path.join(base, 'steamapps', 'compatdata', appid, 'pfx') : null
+        });
+      }
     }
   }
   return games;
@@ -249,4 +275,4 @@ function discover(extraFolders = [], scanDrives = false, excludedRoots = [], fin
   return { games: dedupe(filterExcluded(found, excludedRoots)), roots };
 }
 
-module.exports = { discover, folder, dedupe, autoRoots, drives, isInside, filterExcluded };
+module.exports = { discover, folder, dedupe, autoRoots, drives, isInside, filterExcluded, steam, linuxSteamRoots };

--- a/test/linux-proton.test.js
+++ b/test/linux-proton.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { steam } = require('../src/library');
+const { protonCandidates } = require('../src/core/proton');
+
+test('Linux Steam discovery finds Proton game libraries and their prefix', (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-linux-steam-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const root = path.join(home, '.local', 'share', 'Steam');
+  const library = path.join(home, 'Games');
+  const apps = path.join(library, 'steamapps');
+  fs.mkdirSync(path.join(apps, 'common', 'Example Game'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'steamapps', 'compatdata', '123', 'pfx'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'appcache', 'librarycache'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'steamapps'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'steamapps', 'libraryfolders.vdf'), `"libraryfolders"\n{\n"0"\n{\n"path" "${library.replace(/\\/g, '\\\\')}"\n}\n}`);
+  fs.writeFileSync(path.join(apps, 'appmanifest_123.acf'), '"AppState" { "appid" "123" "name" "Example Game" "installdir" "Example Game" }');
+
+  const games = steam({ platform: 'linux', home });
+  assert.equal(games.length, 1);
+  assert.equal(games[0].id, '123');
+  assert.equal(games[0].protonPrefix, path.join(root, 'steamapps', 'compatdata', '123', 'pfx'));
+});
+
+test('configured Proton tool is preferred for a Steam prefix', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-proton-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const prefix = path.join(root, 'steamapps', 'compatdata', '123', 'pfx');
+  for (const version of ['Proton 8.0', 'Proton 9.0']) {
+    const file = path.join(root, 'steamapps', 'common', version, 'proton');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, '');
+  }
+  fs.mkdirSync(prefix, { recursive: true });
+  fs.writeFileSync(path.join(path.dirname(prefix), 'config_info'), 'Proton 9.0');
+  assert.equal(protonCandidates(root, prefix)[0], path.join(root, 'steamapps', 'common', 'Proton 9.0', 'proton'));
+});


### PR DESCRIPTION
## Summary
- discover Steam libraries on Linux, including Flatpak
- run ReShade Setup in each game's existing Proton prefix
- add AppImage and deb build configuration
- document the Proton-only scope and block the unsupported Vulkan Feeder route

## Validation
- `npm test` (32 tests passed)