### PR TITLE
Linux: finish the install path, and add Heroic and Lutris

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ in Settings instead.
 
 **What works**
 
-- Swapping the DLSS runtime, and the OptiScaler route including its Vulkan path.
+- Swapping the DLSS runtime on a game that already has DLSS, and the OptiScaler route including
+  its Vulkan path.
 - ReShade Setup, run inside the prefix the game already uses — the Steam Play prefix, or the Wine
   prefix Heroic or Lutris made for it. Installs that never reach the setup do not need a prefix at
   all.
@@ -90,14 +91,19 @@ in Settings instead.
 
 **What does not**
 
-- **Vulkan through the Feeder.** It registers ReShade as a Windows implicit layer, and nothing on
-  Linux loads that: Wine hands layer enumeration to the host Vulkan loader, which loads `.so`
-  layers and never a Windows ReShade DLL. Use the OptiScaler route for Vulkan.
+- **The Feeder route**, which is refused outright. It patched launchers rather than games and left
+  Proton titles unable to start — found by [Febsho](https://github.com/Febsho/DLSS5-Swapper-Linux),
+  who shipped Linux builds and watched them break. Vulkan never reached it here anyway: the Feeder
+  registers ReShade as a Windows implicit layer, and Wine hands layer enumeration to the host
+  Vulkan loader, which loads `.so` layers and never a Windows ReShade DLL. Use Native DLSS, or
+  OptiScaler for Vulkan.
+- **A game that already has a non-add-on ReShade.** The existing proxy may belong to another mod or
+  loader, and replacing it crashed otherwise healthy games. Same source.
 - **Lutris games on a Proton runner**, which is launched through umu, and **Heroic CrossOver
   bottles**. Both are found and can still take a plain DLL swap; only the ReShade Setup step is
   unavailable.
 - **Emulators**, in practice. The Linux builds people actually run are native, and the Windows
-  builds that would work under Wine reach DLSS through Vulkan, which is the route above.
+  builds that would work under Wine go through the Feeder, which is refused above.
 - The OptiScaler GPU gate compares the NVIDIA driver against a Windows version number, and the
   Linux driver does not use the same numbering. That threshold has not been checked against the
   real DLSS 5 requirement.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Compatibility varies by renderer and game. Xenia HUD correction remains experime
 - **Anti-cheat:** red warning and optional confirmation, not a blanket block. Injection can cause crashes or account bans; the app never bypasses anti-cheat.
 - **Requirements:** Feeder needs Visual C++ runtimes (x64, plus x86 for 32-bit games). Some components download on first use.
 - **Compatibility is not guaranteed.** Keep backups; existing mods may conflict. Not every reported game crash is fixed.
-- **Linux/Proton:** source only and untested against a real game — see [Linux](#linux).
+- **Linux/Proton:** source only, and tried with stand-in DLLs rather than the real DLSS runtime — see [Linux](#linux).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ in Settings instead.
 **What works**
 
 - Swapping the DLSS runtime on a game that already has DLSS, and the OptiScaler route including
-  its Vulkan path. Neural Rendering has been seen running this way: `inline feature 18 evaluation
-  succeeded ... 2560x1440 [native]`, frame after frame, in a real Proton game.
+  its Vulkan path — as an install. Whether Neural Rendering then renders correctly is a separate
+  question, answered below.
 - ReShade Setup, run inside the prefix the game already uses — the Steam Play prefix, or the Wine
   prefix Heroic or Lutris made for it. Installs that never reach the setup do not need a prefix at
   all.
@@ -105,9 +105,14 @@ in Settings instead.
   unavailable.
 - **Emulators**, in practice. The Linux builds people actually run are native, and the Windows
   builds that would work under Wine go through the Feeder, which is refused above.
-- **Toggling Neural Rendering off and on in the add-on's overlay**, which crashes the game a few
-  seconds later: `EXCEPTION_ACCESS_VIOLATION reading address 0xffffffffffffffff`. Neural Rendering
-  itself is stable; it is the teardown that is not. Leave it on — it is on by default.
+- **Neural Rendering itself, visually.** It initialises, creates its feature, and costs real frame
+  time — the same menu runs at 129 fps with it off and 54 with it on — but what it draws is black.
+  The scene disappears. The log tells the flattering half of this story: `feature 18 created` on
+  every toggle, and `inline feature 18 evaluation succeeded` on a fresh start, which is why an
+  earlier version of this file claimed it worked. It does not; that claim was made from the log
+  rather than from the screen, and the screen disagrees.
+- **Toggling it off and on** has also crashed the game a few seconds later, once, with
+  `EXCEPTION_ACCESS_VIOLATION reading address 0xffffffffffffffff`.
 - The OptiScaler GPU gate compares the NVIDIA driver against a Windows version number, and the
   Linux driver does not use the same numbering. That threshold has not been checked against the
   real DLSS 5 requirement.
@@ -123,7 +128,8 @@ protontricks <appid> d3dcompiler_47
 ```
 
 Without it the log fills with `proxy encode compilation failed ... Function "isnan" is not
-defined`; with it, that error is gone entirely.
+defined`; with it, that error is gone entirely. It is still needed even though Neural Rendering
+does not render correctly afterwards — without it, nothing happens at all.
 
 **Running it**
 
@@ -139,7 +145,8 @@ starts and lists your games but cannot install. `npm run build:linux` needs it t
 `scripts/collect-payload.js`.
 
 > Tried against a real Steam Play game, twice over: once on a copy of its files with stand-in DLLs,
-> and once for real with an actual DLSS 5 payload, where the game launched and Neural Rendering ran.
+> and once for real with an actual DLSS 5 payload, where the game launched and the add-on loaded —
+> though Neural Rendering renders black, so what is verified is the install, not the result.
 > On the copy, an install and a restore ran end to end: the library
 > finds the game, the process guard reads `/proc`, the installer replaces the game's `nvngx_dlss.dll`
 > against its backup and adds the runtime, add-on and hook beside the executable, ReShade Setup

--- a/README.md
+++ b/README.md
@@ -121,9 +121,12 @@ Feeder components. It is not in the repository and has to be supplied yourself; 
 starts and lists your games but cannot install. `npm run build:linux` needs it too. See
 `scripts/collect-payload.js`.
 
-> None of the Linux path has been tested against a real installed game. File locations and the
-> environment each launcher uses were read out of Heroic's and Lutris' own shipped code, and the
-> behaviour is covered by the test suite, but treat it as untried and keep your backups.
+> Partly tried against a real Steam Play game. What has run: the library finds it, the process
+> guard reads `/proc`, and ReShade Setup executes inside the game's own Proton prefix and leaves a
+> working add-on-capable `dxgi.dll` (6.8.0) that this app's own scanner accepts. What has not: the
+> DLSS runtime swap and restore, which need the payload; Heroic and Lutris, whose file locations
+> were read out of their own shipped code rather than tried against an install; and the OptiScaler
+> route, which needs an RTX 50. Keep your backups.
 
 ## Emulators
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ in Settings instead.
 **What works**
 
 - Swapping the DLSS runtime on a game that already has DLSS, and the OptiScaler route including
-  its Vulkan path.
+  its Vulkan path. Neural Rendering has been seen running this way: `inline feature 18 evaluation
+  succeeded ... 2560x1440 [native]`, frame after frame, in a real Proton game.
 - ReShade Setup, run inside the prefix the game already uses — the Steam Play prefix, or the Wine
   prefix Heroic or Lutris made for it. Installs that never reach the setup do not need a prefix at
   all.
@@ -104,9 +105,25 @@ in Settings instead.
   unavailable.
 - **Emulators**, in practice. The Linux builds people actually run are native, and the Windows
   builds that would work under Wine go through the Feeder, which is refused above.
+- **Toggling Neural Rendering off and on in the add-on's overlay**, which crashes the game a few
+  seconds later: `EXCEPTION_ACCESS_VIOLATION reading address 0xffffffffffffffff`. Neural Rendering
+  itself is stable; it is the teardown that is not. Leave it on — it is on by default.
 - The OptiScaler GPU gate compares the NVIDIA driver against a Windows version number, and the
   Linux driver does not use the same numbering. That threshold has not been checked against the
   real DLSS 5 requirement.
+
+**One thing Proton needs first**
+
+The add-on compiles a shader at runtime, and Wine's `d3dcompiler_47` — 370 KB, backed by vkd3d's
+incomplete HLSL compiler — does not implement `isnan`, so that compile fails and Neural Rendering
+never runs. Microsoft's own 4 MB DLL does. Install it into the game's prefix once:
+
+```bash
+protontricks <appid> d3dcompiler_47
+```
+
+Without it the log fills with `proxy encode compilation failed ... Function "isnan" is not
+defined`; with it, that error is gone entirely.
 
 **Running it**
 
@@ -121,8 +138,9 @@ Feeder components. It is not in the repository and has to be supplied yourself; 
 starts and lists your games but cannot install. `npm run build:linux` needs it too. See
 `scripts/collect-payload.js`.
 
-> Tried against a real Steam Play game — on a copy of its files, with stand-in DLLs in place of the
-> DLSS runtime this repository cannot ship. An install and a restore ran end to end: the library
+> Tried against a real Steam Play game, twice over: once on a copy of its files with stand-in DLLs,
+> and once for real with an actual DLSS 5 payload, where the game launched and Neural Rendering ran.
+> On the copy, an install and a restore ran end to end: the library
 > finds the game, the process guard reads `/proc`, the installer replaces the game's `nvngx_dlss.dll`
 > against its backup and adds the runtime, add-on and hook beside the executable, ReShade Setup
 > executes inside the game's own Proton prefix and leaves an add-on-capable `dxgi.dll` (6.8.0), and

--- a/README.md
+++ b/README.md
@@ -121,12 +121,15 @@ Feeder components. It is not in the repository and has to be supplied yourself; 
 starts and lists your games but cannot install. `npm run build:linux` needs it too. See
 `scripts/collect-payload.js`.
 
-> Partly tried against a real Steam Play game. What has run: the library finds it, the process
-> guard reads `/proc`, and ReShade Setup executes inside the game's own Proton prefix and leaves a
-> working add-on-capable `dxgi.dll` (6.8.0) that this app's own scanner accepts. What has not: the
-> DLSS runtime swap and restore, which need the payload; Heroic and Lutris, whose file locations
-> were read out of their own shipped code rather than tried against an install; and the OptiScaler
-> route, which needs an RTX 50. Keep your backups.
+> Tried against a real Steam Play game — on a copy of its files, with stand-in DLLs in place of the
+> DLSS runtime this repository cannot ship. An install and a restore ran end to end: the library
+> finds the game, the process guard reads `/proc`, the installer replaces the game's `nvngx_dlss.dll`
+> against its backup and adds the runtime, add-on and hook beside the executable, ReShade Setup
+> executes inside the game's own Proton prefix and leaves an add-on-capable `dxgi.dll` (6.8.0), and
+> restore puts all eleven files back byte for byte and removes everything it added. What that cannot
+> show is whether NVIDIA's own runtime then works: the stand-ins are valid PE files and nothing more.
+> Heroic and Lutris are still untried against an install, and the OptiScaler route needs an RTX 50.
+> Keep your backups.
 
 ## Emulators
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ starts and lists your games but cannot install. `npm run build:linux` needs it t
 > executes inside the game's own Proton prefix and leaves an add-on-capable `dxgi.dll` (6.8.0), and
 > restore puts all eleven files back byte for byte and removes everything it added. What that cannot
 > show is whether NVIDIA's own runtime then works: the stand-ins are valid PE files and nothing more.
-> Heroic and Lutris are still untried against an install, and the OptiScaler route needs an RTX 50.
-> Keep your backups.
+> Heroic has been tried the same way: the reader finds an Epic game, resolves its prefix and wine
+> build out of Heroic's own config, and ReShade Setup runs inside that prefix too — which Heroic had
+> set to Proton rather than plain Wine, so that branch is exercised as well. Lutris is still untried
+> against an install, and the OptiScaler route needs an RTX 50. Keep your backups.
 
 ## Emulators
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Windows DLSS payload and is skipped.
 | Launcher | Notes |
 | --- | --- |
 | **Steam Play** | Native, and the Flatpak install. The game's own `compatdata` prefix is used |
-| **Heroic** | Epic, GOG, Amazon and sideloaded games; native and Flatpak |
+| **Heroic** | Epic, GOG, Amazon and sideloaded games; native and Flatpak. A DLC listed as its own install (Cyberpunk 2077's REDmod, found this way) is skipped rather than mistaken for the base game |
 | **Lutris** | Wine games; native and Flatpak |
 
 Full-drive scanning finds nothing here — it enumerates Windows drive letters. Add folders by hand
@@ -112,7 +112,13 @@ in Settings instead.
   earlier version of this file claimed it worked. It does not; that claim was made from the log
   rather than from the screen, and the screen disagrees.
 - **Toggling it off and on** has also crashed the game a few seconds later, once, with
-  `EXCEPTION_ACCESS_VIOLATION reading address 0xffffffffffffffff`.
+  `EXCEPTION_ACCESS_VIOLATION reading address 0xffffffffffffffff`. The same exact address turned
+  up again crashing a second, unrelated game (Cyberpunk 2077, on a completely different Proton
+  build) the moment its Neural Rendering feature was first created rather than toggled — which
+  reads as one bug in the add-on's feature lifecycle under Proton, not an engine quirk or a build
+  quirk. Both crash reports named `stopThreadID`/thread IDs matching the thread the log shows
+  building that feature, and both times CDPR's or the game's own crash reporter came up
+  independently of ReShade, confirming a real crash rather than a caught exception.
 - The OptiScaler GPU gate compares the NVIDIA driver against a Windows version number, and the
   Linux driver does not use the same numbering. That threshold has not been checked against the
   real DLSS 5 requirement.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://github.com/rakanki911/DLSS5-Swapper/releases/latest"><img src="https://img.shields.io/github/v/release/rakanki911/DLSS5-Swapper?color=8fd400&label=release" alt="Latest release"></a>
   <a href="https://github.com/rakanki911/DLSS5-Swapper/releases"><img src="https://img.shields.io/github/downloads/rakanki911/DLSS5-Swapper/total?color=8fd400&label=downloads&cacheSeconds=300" alt="Total downloads"></a>
   <img src="https://img.shields.io/badge/Windows-10%20%2F%2011-8fd400" alt="Windows 10/11">
+  <img src="https://img.shields.io/badge/Linux-Proton%20%2F%20Wine-8fd400" alt="Linux via Proton or Wine">
   <img src="https://img.shields.io/badge/languages-38-8fd400" alt="38 languages">
 </p>
 
@@ -28,7 +29,7 @@
 ## Features
 
 - **Easy installation:** native DLSS games, or compatible non-DLSS games through DLSS5-Feeder.
-- **Your library:** Steam, Epic, GOG, modern Xbox Game Pass folders, and manually added games/emulators.
+- **Your library:** Steam, Epic, GOG, modern Xbox Game Pass folders, and manually added games/emulators. On Linux: Steam Play, Heroic and Lutris.
 - **Search and filters:** combine title, graphics API, DLSS status/version and add-ons; click counters to filter.
 - **Flexible layout:** group by store or show everything in one list, with game artwork and light/dark themes.
 - **Controlled scanning:** full-drive scanning is **off by default**. Added folders still scan normally; enable all-drive discovery or remove scan folders in Settings.
@@ -51,17 +52,72 @@
 
 | Category | Support |
 | --- | --- |
-| **System** | Windows 10/11 x64; compatible 32-bit and 64-bit games |
+| **System** | Windows 10/11 x64; compatible 32-bit and 64-bit games. Linux: Windows games run through Proton or Wine — see [Linux](#linux) |
 | **ReShade / Feeder GPUs** | RTX 20 / 30 / 40 / 50; older-series support is reported by the bundled modified runtime's author |
 | **OptiScaler GPUs** | RTX 50 only, NVIDIA driver **616.56+**, 64-bit games with native DLSS enabled |
 | **DirectX 12** | Native DLSS, Feeder, or eligible OptiScaler games |
 | **DirectX 11** | Feeder for 32/64-bit games; eligible OptiScaler games |
 | **DirectX 9 / 8** | DX9: 32/64-bit; DX8: 32-bit, through dgVoodoo2 → DX11 → Feeder |
-| **Vulkan / OpenGL** | ReShade/Feeder; eligible Vulkan games can also use OptiScaler |
+| **Vulkan / OpenGL** | ReShade/Feeder; eligible Vulkan games can also use OptiScaler. On Linux, Vulkan is OptiScaler only |
 | **DirectX 10** | Not directly supported by Feeder; choose DX11 when available |
 
 OptiScaler's DX11/Vulkan path uses a DX12 bridge with FSR output by default.
 For Vulkan backend changes, **restore originals first**. OptiScaler is not the emulator/non-DLSS route.
+
+## Linux
+
+Windows games launched through Proton or Wine. A Linux-native build of a game cannot load the
+Windows DLSS payload and is skipped.
+
+**What is found**
+
+| Launcher | Notes |
+| --- | --- |
+| **Steam Play** | Native, and the Flatpak install. The game's own `compatdata` prefix is used |
+| **Heroic** | Epic, GOG, Amazon and sideloaded games; native and Flatpak |
+| **Lutris** | Wine games; native and Flatpak |
+
+Full-drive scanning finds nothing here — it enumerates Windows drive letters. Add folders by hand
+in Settings instead.
+
+**What works**
+
+- Swapping the DLSS runtime, and the OptiScaler route including its Vulkan path.
+- ReShade Setup, run inside the prefix the game already uses — the Steam Play prefix, or the Wine
+  prefix Heroic or Lutris made for it. Installs that never reach the setup do not need a prefix at
+  all.
+- The "close the game first" check, which reads `/proc` rather than asking PowerShell.
+
+**What does not**
+
+- **Vulkan through the Feeder.** It registers ReShade as a Windows implicit layer, and nothing on
+  Linux loads that: Wine hands layer enumeration to the host Vulkan loader, which loads `.so`
+  layers and never a Windows ReShade DLL. Use the OptiScaler route for Vulkan.
+- **Lutris games on a Proton runner**, which is launched through umu, and **Heroic CrossOver
+  bottles**. Both are found and can still take a plain DLL swap; only the ReShade Setup step is
+  unavailable.
+- **Emulators**, in practice. The Linux builds people actually run are native, and the Windows
+  builds that would work under Wine reach DLSS through Vulkan, which is the route above.
+- The OptiScaler GPU gate compares the NVIDIA driver against a Windows version number, and the
+  Linux driver does not use the same numbering. That threshold has not been checked against the
+  real DLSS 5 requirement.
+
+**Running it**
+
+There are no Linux binaries. Run from source (tested on Node 24):
+
+```bash
+npm install && npm start
+```
+
+Installing anything also needs the `payload/` folder — the DLSS 5 runtime, ReShade Setup and the
+Feeder components. It is not in the repository and has to be supplied yourself; without it the app
+starts and lists your games but cannot install. `npm run build:linux` needs it too. See
+`scripts/collect-payload.js`.
+
+> None of the Linux path has been tested against a real installed game. File locations and the
+> environment each launcher uses were read out of Heroic's and Lutris' own shipped code, and the
+> behaviour is covered by the test suite, but treat it as untried and keep your backups.
 
 ## Emulators
 
@@ -109,7 +165,7 @@ Compatibility varies by renderer and game. Xenia HUD correction remains experime
 - **Anti-cheat:** red warning and optional confirmation, not a blanket block. Injection can cause crashes or account bans; the app never bypasses anti-cheat.
 - **Requirements:** Feeder needs Visual C++ runtimes (x64, plus x86 for 32-bit games). Some components download on first use.
 - **Compatibility is not guaranteed.** Keep backups; existing mods may conflict. Not every reported game crash is fixed.
-- **Linux/Proton:** experimental community source only; no Linux binaries in this release.
+- **Linux/Proton:** source only and untested against a real game — see [Linux](#linux).
 
 ---
 

--- a/main.js
+++ b/main.js
@@ -763,6 +763,22 @@ ipcMain.handle('details', async (_event, dir) => {
 });
 
 let mutationBusy = false;
+// Steam keeps its data under two roots that are symlinked to one another, so
+// the same game is discoverable under either path and a plain string compare
+// misses half of them. Compare what the paths resolve to on disk instead.
+function protonGame(dir) {
+  const real = (file) => { try { return fs.realpathSync(file); } catch { return path.resolve(file); } };
+  const target = real(dir);
+  return steam().find((game) => real(game.dir) === target) || null;
+}
+
+// The install reached ReShade Setup on a game with no Steam Play prefix to run
+// it in. Throw where the installer already handles a failed setup: it keeps a
+// recoverable checkpoint and the journal rolls the rest back.
+function protonRequired() {
+  throw Object.assign(new Error('This step runs the Windows ReShade Setup and needs the game’s Steam Play prefix. Launch the game once with Proton, then try again.'), { code: 'errProtonRequired' });
+}
+
 async function exclusiveMutation(work) {
   if (mutationBusy) return { ok: false, code: 'errJobBusy' };
   mutationBusy = true;
@@ -793,16 +809,15 @@ ipcMain.handle('install', (event, dir, exePath, requestedRoute, requestedApi) =>
   const route = availableRoutes.includes(requestedRoute) ? requestedRoute
     : (availableRoutes.includes(recommendedRoute) ? recommendedRoute : availableRoutes[0]);
 
-  // ReShade Setup is a Windows executable. On Linux, support Windows games
-  // launched with Steam Play by using their existing Proton prefix; native
-  // Linux games do not load the Windows DLSS/ReShade payload.
-  const protonGame = process.platform === 'linux'
-    ? steam().find((game) => path.resolve(game.dir) === path.resolve(dir))
-    : null;
-  const proton = contextForSteamGame(protonGame);
-  if (process.platform === 'linux' && !proton) {
-    return { ok: false, code: 'errProtonRequired', message: 'This installer supports Windows games launched through Steam Proton. Launch the game once with Proton, then try again.' };
-  }
+  // ReShade Setup is a Windows executable, and on Linux it runs in the Steam
+  // Play prefix the game already has. Everything else an install does - copying
+  // DLLs, writing configs - is ordinary file IO that needs no prefix, and a
+  // game that already carries an add-on ReShade never reaches the setup at all.
+  // So a missing prefix is only fatal for an install that actually gets there:
+  // hand the installer a runner that refuses instead of refusing up front, and
+  // let the journal roll back the half-done install the same way it would for
+  // any other failed setup.
+  const proton = process.platform === 'linux' ? contextForSteamGame(protonGame(dir)) : null;
   if (process.platform === 'linux' && api === 'vulkan') {
     return { ok: false, code: 'errLinuxVulkanUnsupported', message: 'The Vulkan Feeder route needs a host Vulkan layer and is not supported on Linux yet. Select a DirectX renderer in the game.' };
   }
@@ -906,7 +921,7 @@ ipcMain.handle('install', (event, dir, exePath, requestedRoute, requestedApi) =>
       optiRoot,
       companions,
       reshadeSetup: p.reshadeSetup,
-      setupRunner: proton ? createSetupRunner(proton) : undefined,
+      setupRunner: process.platform === 'linux' ? (proton ? createSetupRunner(proton) : protonRequired) : undefined,
       vulkanLayerTarget: path.join(app.getPath('userData'), 'reshade-vulkan'),
       installReShade: true,
       addMissingDlss: true,

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ const crypto = require('crypto');
 
 const { scanGame } = require('./src/core/scan.js');
 const { discover, folder, dedupe, isInside, steam, heroic, lutris } = require('./src/library');
-const { contextForGame, createSetupRunner } = require('./src/core/proton');
+const { contextForGame, createSetupRunner, nativeShaderCompiler } = require('./src/core/proton');
 const art = require('./src/steamart');
 const { backupRoot } = require('./src/core/apply.js');
 const { scanSource } = require('./src/core/scan.js');
@@ -836,6 +836,14 @@ ipcMain.handle('install', (event, dir, exePath, requestedRoute, requestedApi) =>
   }
 
   const send = (e) => event.sender.send('job', e);
+  // Warn rather than refuse: the install itself is fine, it is what happens on
+  // the next launch that is not. Without Microsoft's d3dcompiler_47 in the
+  // prefix, the add-on's runtime shader compile fails and Neural Rendering
+  // never starts, while everything reports success - so say so here, where
+  // there is still someone reading, rather than leave it to a silent no-op.
+  if (proton && !nativeShaderCompiler(proton.env.WINEPREFIX)) {
+    send({ code: 'shaderCompilerWarning', params: { appid: proton.env.STEAM_COMPAT_APP_ID || '' } });
+  }
   await guards.assertGameClosed(dir, target.path);
   if (fs.existsSync(journal.pendingPath(dir))) return { ok: false, code: 'errBackendRecovery' };
   const old = backends.readManifest(dir);

--- a/main.js
+++ b/main.js
@@ -9,8 +9,8 @@ const { pathToFileURL } = require('url');
 const crypto = require('crypto');
 
 const { scanGame } = require('./src/core/scan.js');
-const { discover, folder, dedupe, isInside, steam } = require('./src/library');
-const { contextForSteamGame, createSetupRunner } = require('./src/core/proton');
+const { discover, folder, dedupe, isInside, steam, heroic, lutris } = require('./src/library');
+const { contextForGame, createSetupRunner } = require('./src/core/proton');
 const art = require('./src/steamart');
 const { backupRoot } = require('./src/core/apply.js');
 const { scanSource } = require('./src/core/scan.js');
@@ -766,17 +766,17 @@ let mutationBusy = false;
 // Steam keeps its data under two roots that are symlinked to one another, so
 // the same game is discoverable under either path and a plain string compare
 // misses half of them. Compare what the paths resolve to on disk instead.
-function protonGame(dir) {
+function bottleFor(dir) {
   const real = (file) => { try { return fs.realpathSync(file); } catch { return path.resolve(file); } };
   const target = real(dir);
-  return steam().find((game) => real(game.dir) === target) || null;
+  return contextForGame([...steam(), ...heroic(), ...lutris()].find((game) => real(game.dir) === target));
 }
 
-// The install reached ReShade Setup on a game with no Steam Play prefix to run
-// it in. Throw where the installer already handles a failed setup: it keeps a
+// The install reached ReShade Setup on a game with no prefix to run it in.
+// Throw where the installer already handles a failed setup: it keeps a
 // recoverable checkpoint and the journal rolls the rest back.
 function protonRequired() {
-  throw Object.assign(new Error('This step runs the Windows ReShade Setup and needs the game’s Steam Play prefix. Launch the game once with Proton, then try again.'), { code: 'errProtonRequired' });
+  throw Object.assign(new Error('This step runs the Windows ReShade Setup and needs the prefix the game is launched with. Start the game once through Steam Play, Heroic or Lutris, then try again.'), { code: 'errProtonRequired' });
 }
 
 async function exclusiveMutation(work) {
@@ -817,7 +817,7 @@ ipcMain.handle('install', (event, dir, exePath, requestedRoute, requestedApi) =>
   // hand the installer a runner that refuses instead of refusing up front, and
   // let the journal roll back the half-done install the same way it would for
   // any other failed setup.
-  const proton = process.platform === 'linux' ? contextForSteamGame(protonGame(dir)) : null;
+  const proton = process.platform === 'linux' ? bottleFor(dir) : null;
   if (process.platform === 'linux' && api === 'vulkan') {
     return { ok: false, code: 'errLinuxVulkanUnsupported', message: 'The Vulkan Feeder route needs a host Vulkan layer and is not supported on Linux yet. Select a DirectX renderer in the game.' };
   }

--- a/main.js
+++ b/main.js
@@ -818,13 +818,21 @@ ipcMain.handle('install', (event, dir, exePath, requestedRoute, requestedApi) =>
   // let the journal roll back the half-done install the same way it would for
   // any other failed setup.
   const proton = process.platform === 'linux' ? bottleFor(dir) : null;
-  // Vulkan through the Feeder registers ReShade as a Windows implicit layer,
-  // and nothing on Linux reads that: winevulkan hands layer enumeration to the
-  // host loader, which loads .so layers and never a Windows ReShade DLL. The
-  // OptiScaler route reaches Vulkan through a proxy DLL in the game folder
-  // instead, which is a plain file copy and works here.
-  if (process.platform === 'linux' && api === 'vulkan' && route === 'feeder') {
-    return { ok: false, code: 'errLinuxVulkanUnsupported', message: 'The Vulkan Feeder route needs a Windows implicit layer, which Proton does not load. Use the OptiScaler route for Vulkan, or select a DirectX renderer in the game.' };
+  // Both guards below come from Febsho, who shipped Linux builds and watched
+  // them break games - https://github.com/Febsho/DLSS5-Swapper-Linux. Field
+  // evidence outranks anything reasoned from here, so they are taken as given.
+  //
+  // The Feeder patched launchers rather than games and left titles unable to
+  // start. Linux keeps the routes that only copy files into the game folder.
+  // (Vulkan never reached the Feeder here anyway: it registers ReShade as a
+  // Windows implicit layer, which Proton does not load - see vulkan-layer.js.)
+  if (process.platform === 'linux' && route === 'feeder') {
+    return { ok: false, code: 'errLinuxFeederUnsupported', message: 'DLSS5-Feeder is disabled on Linux because it can leave a Proton game unable to start. Use Native DLSS on a game that already has it, or OptiScaler where the hardware allows.' };
+  }
+  // An existing proxy may belong to another mod or loader, and replacing it
+  // was a cause of Proton startup crashes in otherwise healthy games.
+  if (process.platform === 'linux' && scan.reshade.installed && !scan.reshade.addonSupport) {
+    return { ok: false, code: 'errExistingReShade', message: 'This game already has a non-add-on ReShade installation. It was left untouched to prevent a Proton crash.' };
   }
 
   const send = (e) => event.sender.send('job', e);

--- a/main.js
+++ b/main.js
@@ -818,8 +818,13 @@ ipcMain.handle('install', (event, dir, exePath, requestedRoute, requestedApi) =>
   // let the journal roll back the half-done install the same way it would for
   // any other failed setup.
   const proton = process.platform === 'linux' ? bottleFor(dir) : null;
-  if (process.platform === 'linux' && api === 'vulkan') {
-    return { ok: false, code: 'errLinuxVulkanUnsupported', message: 'The Vulkan Feeder route needs a host Vulkan layer and is not supported on Linux yet. Select a DirectX renderer in the game.' };
+  // Vulkan through the Feeder registers ReShade as a Windows implicit layer,
+  // and nothing on Linux reads that: winevulkan hands layer enumeration to the
+  // host loader, which loads .so layers and never a Windows ReShade DLL. The
+  // OptiScaler route reaches Vulkan through a proxy DLL in the game folder
+  // instead, which is a plain file copy and works here.
+  if (process.platform === 'linux' && api === 'vulkan' && route === 'feeder') {
+    return { ok: false, code: 'errLinuxVulkanUnsupported', message: 'The Vulkan Feeder route needs a Windows implicit layer, which Proton does not load. Use the OptiScaler route for Vulkan, or select a DirectX renderer in the game.' };
   }
 
   const send = (e) => event.sender.send('job', e);

--- a/scripts/collect-payload.js
+++ b/scripts/collect-payload.js
@@ -289,7 +289,19 @@ if (!fs.existsSync(path.join(reshadeExtract, 'ReShade64.dll'))) {
   fs.mkdirSync(reshadeExtract, { recursive: true });
   // ReShade Setup is a self-extracting executable with a ZIP appended. BSD
   // tar handles that layout; extract-zip rejects its non-standard comment.
-  execFileSync('tar', ['-xf', reshade.file, '-C', reshadeExtract], { stdio: 'inherit' });
+  // Windows ships bsdtar as `tar`, which is why this reads as one command
+  // there. On Linux `tar` is GNU tar, which refuses the stub outright - so
+  // find one that is actually libarchive rather than trusting the name.
+  const extractor = ['bsdtar', 'tar'].find((candidate) => {
+    try { return /bsdtar|libarchive/i.test(execFileSync(candidate, ['--version'], { encoding: 'utf8' })); }
+    catch { return false; }
+  });
+  if (!extractor) {
+    console.error('\nNo bsdtar found, and GNU tar cannot read a self-extracting installer.');
+    console.error('Install libarchive (bsdtar) and run again.');
+    process.exit(1);
+  }
+  execFileSync(extractor, ['-xf', reshade.file, '-C', reshadeExtract], { stdio: 'inherit' });
 }
 for (const name of ['ReShade64.dll', 'ReShade64.json', 'ReShade32.dll', 'ReShade32.json']) {
   copyFile(path.join(reshadeExtract, name), path.join(PAYLOAD, 'reshade-vulkan', name));

--- a/src/core/install-guards.js
+++ b/src/core/install-guards.js
@@ -6,23 +6,110 @@ function run(file, args) {
   return new Promise((resolve, reject) => execFile(file, args, { windowsHide: true, timeout: 20000, maxBuffer: 4 * 1024 * 1024 },
     (error, stdout) => error ? reject(error) : resolve(stdout)));
 }
+// A path is the game's when it is the folder itself or something under it.
+// Comparison stays case-insensitive on both platforms: the executable name
+// wine reports does not always match the case on disk.
+function contains(gameDir, file) {
+  const root = path.resolve(gameDir).toLowerCase();
+  const full = path.resolve(file).toLowerCase();
+  return full === root || full.startsWith(root + path.sep);
+}
 function matchingProcesses(processes, gameDir, exePath) {
-  const root = path.resolve(gameDir).toLowerCase() + path.sep;
   return processes.filter(p => {
     if (p.ProcessId === process.pid) return false;
-    if (p.ExecutablePath) return path.resolve(p.ExecutablePath).toLowerCase().startsWith(root);
+    if (p.ExecutablePath) return contains(gameDir, p.ExecutablePath);
     // Protected processes may omit their path. Fail conservatively for a
     // matching executable/helper name, but not unrelated system processes.
     return [exePath ? path.basename(exePath).toLowerCase() : null, 'dlss5-feed-host64.exe'].includes(String(p.Name).toLowerCase());
   });
 }
-async function assertGameClosed(gameDir, exePath, runner = run) {
+
+// ---------- process snapshots ----------
+// Both platforms return the same rows: { ProcessId, Name, ExecutablePath }.
+
+function windowsSnapshot() {
   const powershell = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32/WindowsPowerShell/v1.0/powershell.exe');
+  return run(powershell, ['-NoProfile', '-NonInteractive', '-Command',
+    "$ErrorActionPreference='Stop'; @(Get-CimInstance Win32_Process | Select-Object ProcessId,Name,ExecutablePath) | ConvertTo-Json -Compress"]);
+}
+
+const PROC = '/proc';
+// comm is truncated to 15 characters, so a long name arrives without its
+// extension; the Proton runtime path is the other half of the signal.
+const WINE = /wine|proton|\.exe$/i;
+const link = (file) => { try { return fs.readlinkSync(file); } catch { return null; } };
+const text = (file) => { try { return fs.readFileSync(file, 'utf8'); } catch { return ''; } };
+
+// Wine hands a program Windows-style argv. Z: is the drive it maps to /, and
+// it is the only letter that resolves back to a real file without reading the
+// prefix's dosdevices - the folder evidence below covers a C: path.
+function unixPath(token) {
+  if (/^[a-z]:[\\/]/i.test(token)) return /^z:[\\/]/i.test(token) ? path.resolve('/', token.slice(3).replace(/\\/g, '/')) : null;
+  return token.startsWith('/') ? token : null;
+}
+
+// The .exe and its DLLs stay mapped for as long as the game runs, which is the
+// one tie to the folder that survives a game that chdir'd away from it.
+function mappedGameFile(dir, gameDir) {
+  const seen = new Set();
+  for (const line of text(path.join(dir, 'maps')).split('\n')) {
+    // Anonymous regions ([heap], [stack]) carry no path; the address, mode,
+    // offset and device fields never contain a slash.
+    const start = line.indexOf('/');
+    if (start < 0) continue;
+    const file = line.slice(start).replace(/ \(deleted\)$/, '');
+    if (seen.has(file)) continue;
+    seen.add(file);
+    if (contains(gameDir, file)) return file;
+  }
+  return null;
+}
+
+// A Proton game is a wine process: /proc/<pid>/exe points into the Proton
+// runtime and never at the game, so its own path can only rule it out
+// wrongly. Steam launches with the game folder as the working directory,
+// which identifies the usual case without reading any maps.
+function gameFile(dir, gameDir, args, exe, comm) {
+  const cwd = link(path.join(dir, 'cwd'));
+  if (cwd && contains(gameDir, cwd)) return cwd;
+  if (exe && contains(gameDir, exe)) return exe;
+  for (const arg of args) {
+    const file = unixPath(arg);
+    if (file && contains(gameDir, file)) return file;
+  }
+  const wine = WINE.test(comm) || (exe && WINE.test(exe)) || args.some((a) => /\.exe$/i.test(a));
+  if (!wine) return exe;
+  return mappedGameFile(dir, gameDir) || null;
+}
+
+function linuxSnapshot(gameDir) {
+  // An unreadable /proc is a failed check, not an idle machine: let it throw.
+  const rows = [];
+  for (const pid of fs.readdirSync(PROC)) {
+    if (!/^\d+$/.test(pid)) continue;
+    const dir = path.join(PROC, pid);
+    const args = text(path.join(dir, 'cmdline')).split('\0').filter(Boolean);
+    const exe = link(path.join(dir, 'exe'));
+    const comm = text(path.join(dir, 'comm')).trim();
+    // The process exited while we were walking the list.
+    if (!args.length && !exe && !comm) continue;
+    const windowsArg = args.find((a) => /\.exe$/i.test(a));
+    rows.push({
+      ProcessId: Number(pid),
+      Name: windowsArg ? windowsArg.split(/[\\/]/).pop() : (exe ? path.basename(exe) : comm),
+      ExecutablePath: gameFile(dir, gameDir, args, exe, comm)
+    });
+  }
+  return rows;
+}
+
+const snapshot = (gameDir) => process.platform === 'win32' ? windowsSnapshot() : linuxSnapshot(gameDir);
+
+async function assertGameClosed(gameDir, exePath, processes = snapshot) {
   let data;
   try {
-    const output = await runner(powershell, ['-NoProfile', '-NonInteractive', '-Command',
-      "$ErrorActionPreference='Stop'; @(Get-CimInstance Win32_Process | Select-Object ProcessId,Name,ExecutablePath) | ConvertTo-Json -Compress"]);
-    data = JSON.parse(output || '[]');
+    const output = await processes(gameDir);
+    data = typeof output === 'string' ? JSON.parse(output || '[]') : (output || []);
   } catch (cause) { throw Object.assign(new Error('errProcessCheck'), { code: 'errProcessCheck', cause }); }
   const matches = matchingProcesses(Array.isArray(data) ? data : [data], gameDir, exePath);
   if (matches.length) throw Object.assign(new Error(`Close the game and helper first: ${matches.map(p => p.Name).join(', ')}`), { code: 'errGameRunning' });
@@ -33,7 +120,7 @@ function gpuSupported(rows) {
 }
 async function gpuInfo(runner = run) {
   try {
-    const output = await runner('nvidia-smi.exe', ['--query-gpu=name,driver_version', '--format=csv,noheader']);
+    const output = await runner(process.platform === 'win32' ? 'nvidia-smi.exe' : 'nvidia-smi', ['--query-gpu=name,driver_version', '--format=csv,noheader']);
     return output.trim().split(/\r?\n/).filter(Boolean).map(line => {
       const [name, driver] = line.split(',').map(s => s.trim());
       return { name, driver };
@@ -56,4 +143,4 @@ function antiCheatPresent(gameDir) {
   }
   return false;
 }
-module.exports = { assertGameClosed, matchingProcesses, gpuInfo, gpuSupported, antiCheatPresent };
+module.exports = { assertGameClosed, matchingProcesses, gpuInfo, gpuSupported, antiCheatPresent, linuxSnapshot };

--- a/src/core/proton.js
+++ b/src/core/proton.js
@@ -42,9 +42,12 @@ function createSetupRunner(context) {
     let output = '';
     child.stdout.on('data', (data) => { output += data.toString(); });
     child.stderr.on('data', (data) => { output += data.toString(); });
-    child.on('error', (error) => resolve({ code: -1, output: error.message }));
-    child.on('close', (code) => resolve({ code, output: output.trim() }));
-    setTimeout(() => { try { child.kill(); } catch {} }, 120000);
+    // The kill timer has to be cleared: left running it keeps the event loop
+    // alive for two minutes after a setup that already finished.
+    const timer = setTimeout(() => { try { child.kill(); } catch {} }, 120000);
+    const settle = (result) => { clearTimeout(timer); resolve(result); };
+    child.on('error', (error) => settle({ code: -1, output: error.message }));
+    child.on('close', (code) => settle({ code, output: output.trim() }));
   });
 }
 

--- a/src/core/proton.js
+++ b/src/core/proton.js
@@ -1,7 +1,8 @@
 'use strict';
 // Runs Windows-only helper programs (currently ReShade Setup) in the exact
-// Steam Play prefix used by a game.  Copying DLLs itself is ordinary Linux IO;
-// only the setup executable needs Proton.
+// bottle a game already uses - a Steam Play prefix, or the wine prefix Heroic
+// or Lutris made for it. Copying DLLs itself is ordinary Linux IO; only the
+// setup executable needs any of this.
 const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
@@ -19,25 +20,55 @@ function protonCandidates(steamRoot, prefix) {
     .filter((file) => fs.existsSync(file));
 }
 
+// A context is everything it takes to run a Windows program against a game's
+// existing bottle: the command, the arguments that come before the program,
+// and the environment that points the whole thing at the prefix.
 function contextForSteamGame(game) {
   if (process.platform !== 'linux' || !game || !game.steamRoot || !game.protonPrefix) return null;
   if (!fs.existsSync(game.protonPrefix)) return null;
   const proton = protonCandidates(game.steamRoot, game.protonPrefix)[0];
-  return proton ? { proton, prefix: game.protonPrefix, steamRoot: game.steamRoot, appid: game.id } : null;
+  if (!proton) return null;
+  return {
+    command: proton,
+    lead: ['run'],
+    env: {
+      WINEPREFIX: game.protonPrefix,
+      STEAM_COMPAT_DATA_PATH: path.dirname(game.protonPrefix),
+      STEAM_COMPAT_CLIENT_INSTALL_PATH: game.steamRoot,
+      STEAM_COMPAT_APP_ID: game.id
+    }
+  };
 }
+
+// Heroic and Lutris run a game against a prefix of their own rather than a
+// Steam Play one. Plain wine only needs to be pointed at it. Heroic can also
+// be configured to use Proton, and points the compatibility path at the
+// prefix folder it configured, with wine's own prefix one level inside.
+function contextForWineGame(game) {
+  if (process.platform !== 'linux' || !game || !game.wine) return null;
+  const { bin, prefix, kind, steamPath } = game.wine;
+  if (!bin || !prefix || !fs.existsSync(prefix)) return null;
+  if (kind !== 'proton') return { command: bin, lead: [], env: { WINEPREFIX: prefix } };
+  return {
+    command: bin,
+    lead: ['run'],
+    env: {
+      WINEPREFIX: path.join(prefix, 'pfx'),
+      STEAM_COMPAT_DATA_PATH: prefix,
+      STEAM_COMPAT_CLIENT_INSTALL_PATH: steamPath || prefix,
+      STEAM_COMPAT_APP_ID: game.id || '0'
+    }
+  };
+}
+
+const contextForGame = (game) => contextForSteamGame(game) || contextForWineGame(game);
 
 function createSetupRunner(context) {
   return (setupExe, args, log) => new Promise((resolve) => {
     log('runningSetup', { setup: path.basename(setupExe), args: args.slice(1).join(' ') });
-    const child = spawn(context.proton, ['run', setupExe, ...args], {
+    const child = spawn(context.command, [...context.lead, setupExe, ...args], {
       cwd: path.dirname(args[0]),
-      env: {
-        ...process.env,
-        WINEPREFIX: context.prefix,
-        STEAM_COMPAT_DATA_PATH: path.dirname(context.prefix),
-        STEAM_COMPAT_CLIENT_INSTALL_PATH: context.steamRoot,
-        STEAM_COMPAT_APP_ID: context.appid
-      }
+      env: { ...process.env, ...context.env }
     });
     let output = '';
     child.stdout.on('data', (data) => { output += data.toString(); });
@@ -51,4 +82,4 @@ function createSetupRunner(context) {
   });
 }
 
-module.exports = { protonCandidates, contextForSteamGame, createSetupRunner };
+module.exports = { protonCandidates, contextForSteamGame, contextForWineGame, contextForGame, createSetupRunner };

--- a/src/core/proton.js
+++ b/src/core/proton.js
@@ -44,6 +44,11 @@ function contextForSteamGame(game) {
 // Steam Play one. Plain wine only needs to be pointed at it. Heroic can also
 // be configured to use Proton, and points the compatibility path at the
 // prefix folder it configured, with wine's own prefix one level inside.
+//
+// That inner `pfx` is not a second folder: Heroic drops a `pfx -> .` symlink
+// inside the prefix so a compatdata-shaped path resolves back onto it. Joining
+// `pfx` is therefore right for both shapes, and is not the redundant-looking
+// mistake it reads as. Checked against a real Heroic Proton prefix.
 function contextForWineGame(game) {
   if (process.platform !== 'linux' || !game || !game.wine) return null;
   const { bin, prefix, kind, steamPath } = game.wine;

--- a/src/core/proton.js
+++ b/src/core/proton.js
@@ -70,6 +70,14 @@ function createSetupRunner(context) {
       cwd: path.dirname(args[0]),
       env: { ...process.env, ...context.env }
     });
+    // Proton's `run` verb sends the program's own output to its log file, so
+    // what arrives here is Proton's diagnostics and not the setup's: a failed
+    // ReShade Setup reports an empty reason. `runinprefix` does preserve it -
+    // measured against a real prefix, 7 lines of reg.exe output against none -
+    // but it also skips the prefix file update and the game/Steam drive
+    // mappings that `run` sets up first, which the setup may well need. Not
+    // worth trading a working install for a better error message without a
+    // real ReShade Setup to test it against.
     let output = '';
     child.stdout.on('data', (data) => { output += data.toString(); });
     child.stderr.on('data', (data) => { output += data.toString(); });

--- a/src/core/proton.js
+++ b/src/core/proton.js
@@ -68,6 +68,27 @@ function contextForWineGame(game) {
 
 const contextForGame = (game) => contextForSteamGame(game) || contextForWineGame(game);
 
+// The add-on compiles a shader at runtime through d3dcompiler_47, and Wine's
+// own build is backed by vkd3d's incomplete HLSL compiler: it has no isnan, so
+// the compile fails and Neural Rendering silently never runs. The add-on still
+// loads and the runtime still reports itself initialised, which makes this
+// close to undiagnosable from inside the game - hence the warning.
+//
+// Microsoft's build implements it and is an order of magnitude larger, which is
+// what tells them apart: 370 KB against 4.1 MB on the two prefixes measured.
+const BUILTIN_COMPILER_MAX = 1024 * 1024;
+
+function nativeShaderCompiler(prefix) {
+  if (!prefix) return false;
+  let size = 0;
+  try { size = fs.statSync(path.join(prefix, 'drive_c', 'windows', 'system32', 'd3dcompiler_47.dll')).size; }
+  catch { return false; }
+  if (size <= BUILTIN_COMPILER_MAX) return false;
+  // A native DLL sitting in the prefix is only reached if the prefix prefers it.
+  try { return /"\*?d3dcompiler_47"\s*=\s*"native/i.test(fs.readFileSync(path.join(prefix, 'user.reg'), 'utf8')); }
+  catch { return false; }
+}
+
 function createSetupRunner(context) {
   return (setupExe, args, log) => new Promise((resolve) => {
     log('runningSetup', { setup: path.basename(setupExe), args: args.slice(1).join(' ') });
@@ -95,4 +116,4 @@ function createSetupRunner(context) {
   });
 }
 
-module.exports = { protonCandidates, contextForSteamGame, contextForWineGame, contextForGame, createSetupRunner };
+module.exports = { protonCandidates, contextForSteamGame, contextForWineGame, contextForGame, createSetupRunner, nativeShaderCompiler };

--- a/src/core/scan.js
+++ b/src/core/scan.js
@@ -28,7 +28,10 @@ const SKIP_DIRS = new Set([
 const MAX_SCAN_DEPTH = 12;
 
 // Installers, launchers and anti-cheat helpers are never the game itself.
-const NOT_A_GAME = /^(unins|setup|install|vcredist|vc_redist|dxsetup|dxwebsetup|oalinst|uninstall|crashreport|crashhandler|easyanticheat|eac|battleye|be_service|launcher|activation|patch|update|dotnetfx|touchup|rapidcrc|autorun|autoplay|quicksfv|readme|config|benchmark|report|helper|service|cleanup|modorganizer|redlauncher|skse\d*_loader|hlds\b|srcds\b|steamerrorreporter|dgvoodoocpl|reshade_setup)/i;
+// The trailing alternative is deliberately unanchored: a name that *ends* in
+// launcher is one too, which is what the Feeder was patching instead of the
+// game (found by Febsho - https://github.com/Febsho/DLSS5-Swapper-Linux).
+const NOT_A_GAME = /^(unins|setup|install|vcredist|vc_redist|dxsetup|dxwebsetup|oalinst|uninstall|crashreport|crashhandler|easyanticheat|eac|battleye|be_service|launcher|activation|patch|update|dotnetfx|touchup|rapidcrc|autorun|autoplay|quicksfv|readme|config|benchmark|report|helper|service|cleanup|modorganizer|redlauncher|skse\d*_loader|hlds\b|srcds\b|steamerrorreporter|dgvoodoocpl|reshade_setup)|launcher(?:\.exe)?$/i;
 
 const DLSS_FILE = /^(nvngx_dlss[a-z_]*\.dll|nvngx\.dll|_nvngx\.dll)$/i;
 const STREAMLINE_FILE = /^sl\.[a-z_]+\.dll$/i;

--- a/src/core/vulkan-layer.js
+++ b/src/core/vulkan-layer.js
@@ -4,11 +4,23 @@
 // therefore registered as an implicit layer for the current Windows user.
 // This follows the same HKCU layout used by ReShade and DLSS5-Autopilot and
 // keeps a reference list so restoring one emulator cannot break another.
+//
+// This mechanism has no Linux counterpart, and writing the key inside a
+// Proton prefix would not give it one: winevulkan forwards layer enumeration
+// to the host loader, which loads Linux .so layers and never a Windows
+// ReShade DLL, and wine does not read the prefix's ImplicitLayers key at all.
+// Vulkan on Linux is reached through the OptiScaler route instead, which
+// installs a proxy DLL into the game folder and never comes through here.
 const fs = require('fs');
 const path = require('path');
 const { execFile } = require('child_process');
 
 const KEY = 'HKCU\\Software\\Khronos\\Vulkan\\ImplicitLayers';
+
+// defaultRunner is the host registry, and only Windows has one. A caller that
+// supplies its own runner supplies its own registry along with it, so the
+// check is on which runner is in use rather than on the platform alone.
+const hostRegistry = (runner) => runner !== defaultRunner || process.platform === 'win32';
 
 function defaultRunner(file, args) {
   return new Promise((resolve) => {
@@ -37,6 +49,8 @@ function samePath(a, b) {
 }
 
 async function existing(runner) {
+  // Nowhere to have registered one, so nothing is registered.
+  if (!hostRegistry(runner)) return null;
   const result = await runner('reg.exe', ['query', KEY]);
   if (result.code !== 0) return null;
   for (const line of String(result.stdout || '').split(/\r?\n/)) {
@@ -49,6 +63,9 @@ async function existing(runner) {
 
 async function register(options) {
   const { sourceDir, targetDir, gameDir, bitness = 64, runner = defaultRunner } = options;
+  // Fail before copying anything. Left to run, this would lay the DLLs down
+  // and then fail on a reg.exe that is not there, with nothing to report.
+  if (!hostRegistry(runner)) throw Object.assign(new Error('errVulkanLayerUnsupported'), { code: 'errVulkanLayerUnsupported' });
   const current = await existing(runner);
   const our64 = path.join(targetDir, 'ReShade64.json');
   const ours = current && samePath(current, our64);

--- a/src/library.js
+++ b/src/library.js
@@ -418,11 +418,18 @@ function folder(root, label = 'My folders', onlyGames = false) {
 
 // One game can be installed twice - a launcher copy and a loose copy. They are
 // different installs, so both are kept; only the exact same folder is merged.
+// Two paths can name one folder. Steam keeps its data under ~/.steam/steam and
+// ~/.local/share/Steam, one a symlink to the other, and both are searched - so
+// resolving the string alone leaves every Steam game in the library twice.
+function folderKey(dir) {
+  try { return fs.realpathSync(dir).toLowerCase(); } catch { return path.resolve(dir).toLowerCase(); }
+}
+
 function dedupe(games) {
   const seen = new Map();
   for (const entry of games) {
     const g = canonicalGame(entry);
-    const key = path.resolve(g.dir).toLowerCase();
+    const key = folderKey(g.dir);
     const existing = seen.get(key);
     // A launcher entry carries a real name and art, so it wins over a folder.
     const dlc = game => /\bdlc\b|phantom liberty/i.test(game.name || '');

--- a/src/library.js
+++ b/src/library.js
@@ -139,6 +139,123 @@ function gog() {
   return games;
 }
 
+// ---------- Heroic ----------
+// Heroic keeps one plain-JSON file per store. Only the installed lists are
+// read: the library caches beside them expire and are often missing, and a
+// title is not worth a stale file when the folder name will do.
+const FLATPAK = { heroic: 'com.heroicgameslauncher.hgl', lutris: 'net.lutris.Lutris' };
+
+// A launcher installed from a distro package and the same one from Flatpak
+// keep separate config trees, and people run both.
+function xdgRoots(home, env, ...tail) {
+  const config = env.XDG_CONFIG_HOME || path.join(home, '.config');
+  return [path.join(config, ...tail), path.join(home, '.var', 'app', FLATPAK[tail[0]], 'config', ...tail)]
+    .filter((dir) => fs.existsSync(dir));
+}
+
+const firstOf = (object, ...keys) => keys.map((key) => object && object[key]).find((value) => typeof value === 'string' && value);
+const listOf = (data, key) => Array.isArray(data) ? data : (data && Array.isArray(data[key]) ? data[key]
+  : (data && typeof data === 'object' ? Object.values(data) : []));
+
+function readJson(file) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; }
+}
+
+// The stores do not agree on their key names and Heroic has moved them
+// between versions, so take whichever spelling is present and let the folder
+// on disk decide whether the entry is still a real install.
+function heroicGame(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const install = entry.install && typeof entry.install === 'object' ? entry.install : entry;
+  const dir = firstOf(install, 'install_path', 'install_dir', 'path') || firstOf(entry, 'install_path', 'install_dir', 'path');
+  if (!dir || !fs.existsSync(dir)) return null;
+  // A native Linux build cannot load the Windows DLSS payload. The platform is
+  // not always recorded; when it is, an explicit non-Windows one is skipped.
+  const platform = firstOf(install, 'platform') || firstOf(entry, 'platform');
+  if (platform && !/^win/i.test(platform)) return null;
+  const name = firstOf(entry, 'title', 'name') || path.basename(dir);
+  if (NOT_A_GAME.test(name)) return null;
+  return { launcher: 'Heroic', id: firstOf(entry, 'app_name', 'appName', 'id') || null, name, dir, poster: null };
+}
+
+function heroic(options = {}) {
+  const home = options.home || os.homedir();
+  const games = [];
+  for (const root of options.roots || xdgRoots(home, options.env || process.env, 'heroic')) {
+    const stores = [
+      [path.join(root, 'legendaryConfig', 'legendary', 'installed.json'), null],
+      [path.join(root, 'nile_config', 'nile', 'installed.json'), 'installed'],
+      [path.join(root, 'gog_store', 'installed.json'), 'installed'],
+      [path.join(root, 'sideload_apps', 'library.json'), 'games']
+    ];
+    for (const [file, key] of stores) {
+      for (const entry of listOf(readJson(file), key)) {
+        const game = heroicGame(entry);
+        if (game) games.push(game);
+      }
+    }
+  }
+  return games;
+}
+
+// ---------- Lutris ----------
+// The install directory lives in Lutris' SQLite database, which would need a
+// driver this app does not ship, and its CLI takes seconds to answer. The
+// per-game config beside the database is plain YAML and holds what matters.
+//
+// Lutris writes these with PyYAML's block style: one unindented section per
+// runner, two-space indented scalars under it. Reading exactly that much is
+// enough for the executable and the keys a relative path resolves against;
+// anything nested deeper is not a scalar we want anyway.
+function yamlSection(text, section) {
+  const values = {};
+  let inside = false;
+  for (const line of text.split('\n')) {
+    if (/^\S/.test(line)) { inside = line.startsWith(section + ':'); continue; }
+    if (!inside) continue;
+    const match = line.match(/^ {2}([A-Za-z_][\w-]*): *(.*)$/);
+    if (!match) continue;
+    const raw = match[2].trim();
+    // A key with nothing after it opens a nested block. An empty string is
+    // written as '' and a missing value as null, so neither is lost here.
+    if (!raw) continue;
+    values[match[1]] = raw.startsWith("'") && raw.endsWith("'") && raw.length > 1
+      ? raw.slice(1, -1).replace(/''/g, "'")
+      : (raw.startsWith('"') && raw.endsWith('"') && raw.length > 1 ? raw.slice(1, -1) : raw);
+  }
+  return values;
+}
+
+const expandHome = (file, home) => file.startsWith('~/') ? path.join(home, file.slice(2)) : file;
+
+function lutris(options = {}) {
+  const home = options.home || os.homedir();
+  const games = [];
+  for (const root of options.roots || xdgRoots(home, options.env || process.env, 'lutris', 'games')) {
+    let files = [];
+    try { files = fs.readdirSync(root).filter((file) => file.endsWith('.yml')); } catch { continue; }
+    for (const file of files) {
+      let text;
+      try { text = fs.readFileSync(path.join(root, file), 'utf8'); } catch { continue; }
+      const game = yamlSection(text, 'game');
+      // Native Linux games are listed here too and cannot load the Windows
+      // payload, so the executable has to be a Windows one.
+      if (!game.exe || !/\.exe$/i.test(game.exe)) continue;
+      let exe = expandHome(game.exe, home);
+      if (!path.isAbsolute(exe)) exe = path.resolve(expandHome(game.working_dir || game.prefix || '', home), exe);
+      const dir = path.dirname(exe);
+      if (!fs.existsSync(dir)) continue;
+      // The file is named <slug>-<unix time>, and the slug is the only name
+      // Lutris keeps outside its database.
+      const slug = file.replace(/\.yml$/i, '').replace(/-\d+$/, '');
+      const name = slug.replace(/[-_]+/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase()).trim();
+      if (!name || NOT_A_GAME.test(name)) continue;
+      games.push({ launcher: 'Lutris', id: slug, name, dir, poster: null });
+    }
+  }
+  return games;
+}
+
 // ---------- loose installs on every drive ----------
 // The launchers above already record their libraries wherever they sit, so a
 // game installed through Steam on E: is found without any of this. What is
@@ -279,7 +396,7 @@ function filterExcluded(games, excludedRoots = []) {
 }
 
 function discover(extraFolders = [], scanDrives = false, excludedRoots = [], findAutoRoots = autoRoots) {
-  const found = [...steam(), ...epic(), ...gog()];
+  const found = [...steam(), ...epic(), ...gog(), ...heroic(), ...lutris()];
   const roots = (scanDrives ? findAutoRoots() : [])
     .filter((root) => !excludedRoots.some((excluded) => isInside(root, excluded)));
   for (const dir of roots) found.push(...folder(dir, 'My folders', true));
@@ -290,4 +407,4 @@ function discover(extraFolders = [], scanDrives = false, excludedRoots = [], fin
   return { games: dedupe(filterExcluded(found, excludedRoots)), roots };
 }
 
-module.exports = { discover, folder, dedupe, autoRoots, drives, isInside, filterExcluded, steam, linuxSteamRoots };
+module.exports = { discover, folder, dedupe, autoRoots, drives, isInside, filterExcluded, steam, linuxSteamRoots, heroic, lutris, yamlSection };

--- a/src/library.js
+++ b/src/library.js
@@ -187,6 +187,13 @@ function readJson(file) {
 function heroicGame(entry) {
   if (!entry || typeof entry !== 'object') return null;
   const install = entry.install && typeof entry.install === 'object' ? entry.install : entry;
+  // A DLC gets its own installed.json entry pointing at the base game's own
+  // folder - Cyberpunk 2077 lists "Cyberpunk 2077 - REDmod" as a separate,
+  // is_dlc:true entry with the identical install_path and no executable of
+  // its own. Skipping it here matters beyond the duplicate: it is also the
+  // entry dedupe() ends up keeping, since neither its title nor "REDmod"
+  // matches the /\bdlc\b/ pattern dedupe uses to prefer the other side.
+  if (install.is_dlc === true || entry.is_dlc === true) return null;
   const dir = firstOf(install, 'install_path', 'install_dir', 'path') || firstOf(entry, 'install_path', 'install_dir', 'path');
   if (!dir || !fs.existsSync(dir)) return null;
   // A native Linux build cannot load the Windows DLSS payload. The platform is

--- a/src/library.js
+++ b/src/library.js
@@ -153,6 +153,26 @@ function xdgRoots(home, env, ...tail) {
     .filter((dir) => fs.existsSync(dir));
 }
 
+// Lutris is deprecating ~/.config/lutris: when that folder is absent it keeps
+// its configuration in the data directory instead, which is where a current
+// install puts the per-game files. Downloaded wine runners always live in the
+// data directory, so both are needed.
+function lutrisRoots(home, env) {
+  const config = env.XDG_CONFIG_HOME || path.join(home, '.config');
+  const data = env.XDG_DATA_HOME || path.join(home, '.local', 'share');
+  const flatpak = path.join(home, '.var', 'app', FLATPAK.lutris);
+  return [[config, data], [path.join(flatpak, 'config'), path.join(flatpak, 'data')]]
+    .map(([configHome, dataHome]) => {
+      const configDir = path.join(configHome, 'lutris');
+      const dataDir = path.join(dataHome, 'lutris');
+      return {
+        games: path.join(fs.existsSync(configDir) ? configDir : dataDir, 'games'),
+        wineDir: path.join(dataDir, 'runners', 'wine')
+      };
+    })
+    .filter((root) => fs.existsSync(root.games));
+}
+
 const firstOf = (object, ...keys) => keys.map((key) => object && object[key]).find((value) => typeof value === 'string' && value);
 const listOf = (data, key) => Array.isArray(data) ? data : (data && Array.isArray(data[key]) ? data[key]
   : (data && typeof data === 'object' ? Object.values(data) : []));
@@ -178,10 +198,30 @@ function heroicGame(entry) {
   return { launcher: 'Heroic', id: firstOf(entry, 'app_name', 'appName', 'id') || null, name, dir, poster: null };
 }
 
+// Heroic writes one settings file per game, keyed inside by the same app name,
+// and falls back to the global defaults for anything the game does not
+// override. Both carry the prefix and the wine build the game is launched with.
+function heroicWine(root, appName, defaults) {
+  const perGame = appName ? readJson(path.join(root, 'GamesConfig', `${appName}.json`)) : null;
+  const settings = { ...defaults, ...((perGame && perGame[appName]) || {}) };
+  const version = settings.wineVersion || {};
+  // A CrossOver bottle is driven by CrossOver's own tooling rather than by
+  // running a binary against a prefix.
+  if (!settings.winePrefix || !version.bin || version.type === 'crossover') return null;
+  return {
+    bin: version.bin,
+    prefix: settings.winePrefix,
+    kind: version.type === 'proton' ? 'proton' : 'wine',
+    steamPath: settings.defaultSteamPath || null
+  };
+}
+
 function heroic(options = {}) {
   const home = options.home || os.homedir();
   const games = [];
   for (const root of options.roots || xdgRoots(home, options.env || process.env, 'heroic')) {
+    const global = readJson(path.join(root, 'config.json'));
+    const defaults = (global && global.defaultSettings) || {};
     const stores = [
       [path.join(root, 'legendaryConfig', 'legendary', 'installed.json'), null],
       [path.join(root, 'nile_config', 'nile', 'installed.json'), 'installed'],
@@ -191,7 +231,7 @@ function heroic(options = {}) {
     for (const [file, key] of stores) {
       for (const entry of listOf(readJson(file), key)) {
         const game = heroicGame(entry);
-        if (game) games.push(game);
+        if (game) games.push({ ...game, wine: heroicWine(root, game.id, defaults) });
       }
     }
   }
@@ -228,15 +268,38 @@ function yamlSection(text, section) {
 
 const expandHome = (file, home) => file.startsWith('~/') ? path.join(home, file.slice(2)) : file;
 
+// The handful of versions Lutris resolves to a system install rather than to
+// a runner it downloaded itself.
+const SYSTEM_WINE = {
+  'winehq-devel': '/opt/wine-devel/bin/wine',
+  'winehq-staging': '/opt/wine-staging/bin/wine',
+  'wine-development': '/usr/lib/wine-development/wine',
+  system: 'wine'
+};
+
+// A downloaded runner sits at <runners>/wine/<version>/bin/wine. A Proton
+// version is launched through umu instead, which is not covered here.
+function lutrisWine(config, wineDir, prefix, home) {
+  if (!prefix || !config.version || /proton/i.test(config.version)) return null;
+  const bin = config.version === 'custom'
+    ? config.custom_wine_path
+    : (SYSTEM_WINE[config.version] || path.join(wineDir, config.version, 'bin', 'wine'));
+  if (!bin) return null;
+  const file = expandHome(bin, home);
+  // A bare name is left for PATH to resolve; a full path has to be there.
+  if (path.isAbsolute(file) && !fs.existsSync(file)) return null;
+  return { bin: file, prefix, kind: 'wine' };
+}
+
 function lutris(options = {}) {
   const home = options.home || os.homedir();
   const games = [];
-  for (const root of options.roots || xdgRoots(home, options.env || process.env, 'lutris', 'games')) {
+  for (const root of options.roots || lutrisRoots(home, options.env || process.env)) {
     let files = [];
-    try { files = fs.readdirSync(root).filter((file) => file.endsWith('.yml')); } catch { continue; }
+    try { files = fs.readdirSync(root.games).filter((file) => file.endsWith('.yml')); } catch { continue; }
     for (const file of files) {
       let text;
-      try { text = fs.readFileSync(path.join(root, file), 'utf8'); } catch { continue; }
+      try { text = fs.readFileSync(path.join(root.games, file), 'utf8'); } catch { continue; }
       const game = yamlSection(text, 'game');
       // Native Linux games are listed here too and cannot load the Windows
       // payload, so the executable has to be a Windows one.
@@ -250,7 +313,11 @@ function lutris(options = {}) {
       const slug = file.replace(/\.yml$/i, '').replace(/-\d+$/, '');
       const name = slug.replace(/[-_]+/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase()).trim();
       if (!name || NOT_A_GAME.test(name)) continue;
-      games.push({ launcher: 'Lutris', id: slug, name, dir, poster: null });
+      const prefix = game.prefix ? expandHome(game.prefix, home) : null;
+      games.push({
+        launcher: 'Lutris', id: slug, name, dir, poster: null,
+        wine: lutrisWine(yamlSection(text, 'wine'), root.wineDir, prefix, home)
+      });
     }
   }
   return games;

--- a/src/renderer/i18n.js
+++ b/src/renderer/i18n.js
@@ -74,6 +74,7 @@ const S = {
     historySnapshot: 'Backup record', historyRecovered: 'Interrupted operation recovered',
     historyLoadFailed: 'Could not load history. Reopen this page to try again.',
     historySaveWarning: 'History could not be read or saved completely. Available entries are shown; copy them before closing the app and check access to the app data folder.',
+    shaderCompilerWarning: appid => `Neural Rendering will not start in this game until its prefix has Microsoft's d3dcompiler_47: Wine's own build cannot compile the add-on's shader, and the failure is silent. Run: protontricks ${appid || '<appid>'} d3dcompiler_47`,
     gamesTitle: 'Games', addGame: 'Add a game', addFolder: 'Add a folder', rescan: 'Rescan',
     searchGames: 'Search games', searchGamesHint: 'Search by game title…',
     filterDlss: 'DLSS status', filterAddon: 'Add-on', clearFilters: 'Clear filters',

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -8,7 +8,7 @@ const state = { games: [], recents: [], history: [], newDlss: null, log: [], the
 const filters = { query: '', api: 'all', dlss: 'all', addon: 'all' };
 const gameFilters = window.gameFilters;
 
-const ORDER = ['Steam', 'Epic Games', 'GOG', 'Added by hand', 'My folders'];
+const ORDER = ['Steam', 'Epic Games', 'GOG', 'Heroic', 'Lutris', 'Added by hand', 'My folders'];
 const rank = (l) => (ORDER.indexOf(l) === -1 ? ORDER.length : ORDER.indexOf(l));
 const short = (v) => (v ? String(v).replace(/\.0$/, '') : null);
 const initials = (name) =>

--- a/test/history-ipc.test.js
+++ b/test/history-ipc.test.js
@@ -39,11 +39,11 @@ test('install/restore IPC records all backends, not failures/cancels, and valida
       } }, clipboard: { writeText: text => { copied = text; } } },
     './src/core/scan.js': { scanGame: async () => {
       if (scanFails) throw new Error('Executable scan is unavailable');
-      return { chosen: target, exeCandidates: [target], hasNativeDlss: true };
+      return { chosen: target, exeCandidates: [target], hasNativeDlss: true, reshade: { installed: false, file: null, kind: null, version: null, addonSupport: false } };
     } },
     './src/core/compatibility': { assertSafeTarget() {}, hasAntiCheat: () => protectedTarget },
     './src/core/install-guards': { assertGameClosed: async () => {}, antiCheatPresent: () => false, gpuInfo: async () => [{}], gpuSupported: () => true },
-    './src/shared/install-routes': { nativeDlssPresent: () => true, routesFor: () => ['native', 'feeder', 'optiscaler'], recommendedRoute: () => 'native' },
+    './src/shared/install-routes': { nativeDlssPresent: () => true, routesFor: () => ['native', second, 'optiscaler'], recommendedRoute: () => 'native' },
     './src/core/runtime-components.js': { missingVCRuntime: () => [], ensureLumenite: async () => null },
     './src/core/optiscaler': { checkConflicts() {}, ensureOptiScaler: async () => root, RELEASE: { version: 'fixture' } },
     './src/core/backend-manager': {
@@ -65,7 +65,11 @@ test('install/restore IPC records all backends, not failures/cancels, and valida
   vm.runInContext(fs.readFileSync(main, 'utf8'), context, { filename: main });
   vm.runInContext(`payload = () => ({ source: { feeder: { ok32: true, ok64: true } } }); companionAddons = () => [];`, context);
   const event = { sender: { send() {} } };
-  for (const route of ['native', 'native', 'feeder', 'optiscaler']) {
+  // The Feeder route is refused on Linux. This test is about what reaches the
+  // history, not about any one route, so it exercises whichever second route
+  // the running platform offers.
+  const second = process.platform === 'linux' ? 'optiscaler' : 'feeder';
+  for (const route of ['native', 'native', second, 'optiscaler']) {
     assert.equal((await handlers.get('install')(event, game, target.path, route, 'dxgi')).ok, true);
   }
   assert.equal(handlers.get('history')().rows.length, 4, 'no renderer.touch call needed');
@@ -76,14 +80,14 @@ test('install/restore IPC records all backends, not failures/cancels, and valida
   assert.equal(handlers.get('history')().rows.length, 4);
   protectedTarget = true;
   const callsBeforeWarning = installedConfigs.length;
-  for (const route of ['native', 'feeder', 'optiscaler']) {
+  for (const route of ['native', second, 'optiscaler']) {
     assert.equal((await handlers.get('install')(event, game, target.path, route, 'dxgi')).cancelled, true);
   }
   assert.equal(installedConfigs.length, callsBeforeWarning, 'cancel never reaches the installer');
   assert.equal(handlers.get('history')().rows.length, 4);
   assert.equal(riskDialogs.length, 3);
   antiCheatResponse = 1; cancel = false;
-  for (const route of ['native', 'feeder', 'optiscaler']) {
+  for (const route of ['native', second, 'optiscaler']) {
     assert.equal((await handlers.get('install')(event, game, target.path, route, 'dxgi')).ok, true);
     assert.equal(installedConfigs.at(-1).antiCheatAcknowledged, true);
   }

--- a/test/linux-launchers.test.js
+++ b/test/linux-launchers.test.js
@@ -126,3 +126,139 @@ test('a tilde in a Lutris path is expanded against the home it was found in', (t
   });
   assert.equal(lutris({ home, env: {} })[0].dir, dir);
 });
+
+const { contextForGame, contextForWineGame, contextForSteamGame, createSetupRunner } = require('../src/core/proton');
+const linuxOnly = { skip: process.platform !== 'linux' ? 'Linux only' : false };
+
+test('a wine game is run by pointing its own binary at its own prefix', linuxOnly, (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-wine-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const prefix = path.join(root, 'prefix');
+  fs.mkdirSync(prefix, { recursive: true });
+
+  const context = contextForWineGame({ id: 'x', wine: { bin: '/usr/bin/wine', prefix, kind: 'wine' } });
+  assert.deepEqual(context, { command: '/usr/bin/wine', lead: [], env: { WINEPREFIX: prefix } });
+
+  // Heroic can be set to Proton instead, and points the compatibility path at
+  // the prefix folder it configured rather than at wine's prefix inside it.
+  const proton = contextForWineGame({ id: '42', wine: { bin: '/opt/proton/proton', prefix, kind: 'proton', steamPath: '/steam' } });
+  assert.deepEqual(proton.lead, ['run']);
+  assert.equal(proton.env.WINEPREFIX, path.join(prefix, 'pfx'));
+  assert.equal(proton.env.STEAM_COMPAT_DATA_PATH, prefix);
+  assert.equal(proton.env.STEAM_COMPAT_CLIENT_INSTALL_PATH, '/steam');
+
+  // A prefix that is not there yet cannot be run against.
+  assert.equal(contextForWineGame({ wine: { bin: '/usr/bin/wine', prefix: path.join(root, 'gone'), kind: 'wine' } }), null);
+  assert.equal(contextForWineGame({ dir: root }), null);
+});
+
+test('a Steam Play prefix is preferred over any wine one on the same game', linuxOnly, (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-both-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const prefix = path.join(root, 'steamapps', 'compatdata', '7', 'pfx');
+  fs.mkdirSync(prefix, { recursive: true });
+  const proton = path.join(root, 'steamapps', 'common', 'Proton 9.0', 'proton');
+  fs.mkdirSync(path.dirname(proton), { recursive: true });
+  fs.writeFileSync(proton, '');
+  const wine = path.join(root, 'wineprefix');
+  fs.mkdirSync(wine);
+
+  const game = { id: '7', steamRoot: root, protonPrefix: prefix, wine: { bin: '/usr/bin/wine', prefix: wine, kind: 'wine' } };
+  assert.equal(contextForGame(game).command, proton);
+  assert.deepEqual(contextForGame(game), contextForSteamGame(game));
+});
+
+test('the setup runner really launches the configured binary inside the prefix', linuxOnly, async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-runner-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const prefix = path.join(root, 'prefix');
+  const gameDir = path.join(root, 'game');
+  fs.mkdirSync(prefix, { recursive: true });
+  fs.mkdirSync(gameDir, { recursive: true });
+
+  // Stands in for wine: reports what it was handed and where it was pointed.
+  const fake = path.join(root, 'fake-wine');
+  fs.writeFileSync(fake, '#!/bin/sh\necho "prefix=$WINEPREFIX"\necho "argv=$*"\n');
+  fs.chmodSync(fake, 0o755);
+
+  const context = contextForWineGame({ wine: { bin: fake, prefix, kind: 'wine' } });
+  const logged = [];
+  const result = await createSetupRunner(context)('/setup/ReShade_Setup.exe',
+    [path.join(gameDir, 'Game.exe'), '--api', 'dxgi', '--headless'], (code) => logged.push(code));
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, new RegExp(`prefix=${prefix}$`, 'm'));
+  assert.match(result.output, /argv=\/setup\/ReShade_Setup\.exe .*Game\.exe --api dxgi --headless/);
+  assert.deepEqual(logged, ['runningSetup']);
+});
+
+test('Heroic reads the prefix from the per-game file, falling back to the global defaults', (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-heroic-wine-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const root = path.join(home, '.config', 'heroic');
+  const dirs = {};
+  for (const name of ['Shared', 'Own', 'Bottled']) {
+    dirs[name] = path.join(home, 'Games', name);
+    fs.mkdirSync(dirs[name], { recursive: true });
+  }
+  tree(root, {
+    'config.json': { defaultSettings: {
+      winePrefix: path.join(home, 'Prefixes', 'shared'),
+      defaultSteamPath: path.join(home, '.steam', 'steam'),
+      wineVersion: { bin: '/usr/bin/wine', type: 'wine', name: 'wine-11.16' }
+    } },
+    'legendaryConfig/legendary/installed.json': {
+      shared: { app_name: 'shared', title: 'Shared', install_path: dirs.Shared },
+      own: { app_name: 'own', title: 'Own', install_path: dirs.Own },
+      bottled: { app_name: 'bottled', title: 'Bottled', install_path: dirs.Bottled }
+    },
+    // This one overrides both the prefix and the wine build.
+    'GamesConfig/own.json': { own: {
+      winePrefix: path.join(home, 'Prefixes', 'own'),
+      wineVersion: { bin: '/opt/proton/proton', type: 'proton' }
+    }, version: 'v0' },
+    // A CrossOver bottle is not driven by running a binary against a prefix.
+    'GamesConfig/bottled.json': { bottled: { winePrefix: path.join(home, 'Bottles', 'x'), wineVersion: { bin: '/x/wine', type: 'crossover' } } }
+  });
+
+  const games = heroic({ home, env: {} });
+  const of = (name) => games.find((game) => game.name === name).wine;
+  assert.deepEqual(of('Shared'), {
+    bin: '/usr/bin/wine', prefix: path.join(home, 'Prefixes', 'shared'), kind: 'wine',
+    steamPath: path.join(home, '.steam', 'steam')
+  });
+  assert.equal(of('Own').kind, 'proton');
+  assert.equal(of('Own').prefix, path.join(home, 'Prefixes', 'own'));
+  assert.equal(of('Bottled'), null);
+});
+
+test('Lutris resolves a downloaded runner, a system one, and leaves Proton alone', (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-lutris-wine-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const prefix = path.join(home, 'Games', 'prefix');
+  const exeDir = path.join(prefix, 'drive_c', 'Game');
+  fs.mkdirSync(exeDir, { recursive: true });
+  const runner = path.join(home, '.local', 'share', 'lutris', 'runners', 'wine', 'wine-ge-8-26', 'bin');
+  fs.mkdirSync(runner, { recursive: true });
+  fs.writeFileSync(path.join(runner, 'wine'), '');
+
+  const yml = (version) => `game:\n  exe: ${path.join(exeDir, 'Game.exe')}\n  prefix: ${prefix}\nwine:\n  version: ${version}\n`;
+  // Lutris keeps its configuration in the data directory when ~/.config/lutris
+  // is absent, which is where a current install puts it.
+  tree(path.join(home, '.local', 'share', 'lutris', 'games'), {
+    'downloaded-1.yml': yml('wine-ge-8-26'),
+    'system-2.yml': yml('system'),
+    'missing-3.yml': yml('wine-ge-9-99'),
+    'ge-runner-4.yml': yml('GE-Proton9-20'),
+    'no-prefix-5.yml': `game:\n  exe: ${path.join(exeDir, 'Game.exe')}\nwine:\n  version: system\n`
+  });
+
+  const games = lutris({ home, env: {} });
+  const of = (id) => games.find((game) => game.id === id).wine;
+  assert.equal(games.length, 5, 'every game is still listed, prefix or not');
+  assert.deepEqual(of('downloaded'), { bin: path.join(runner, 'wine'), prefix, kind: 'wine' });
+  assert.deepEqual(of('system'), { bin: 'wine', prefix, kind: 'wine' });
+  assert.equal(of('missing'), null, 'a runner that is not downloaded yet');
+  assert.equal(of('ge-runner'), null, 'Proton is launched through umu, not covered here');
+  assert.equal(of('no-prefix'), null);
+});

--- a/test/linux-launchers.test.js
+++ b/test/linux-launchers.test.js
@@ -262,3 +262,25 @@ test('Lutris resolves a downloaded runner, a system one, and leaves Proton alone
   assert.equal(of('ge-runner'), null, 'Proton is launched through umu, not covered here');
   assert.equal(of('no-prefix'), null);
 });
+
+test('one folder reached by two paths is one game, not two', linuxOnly, (t) => {
+  const { dedupe } = require('../src/library');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-dedupe-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  // Steam's two data roots, exactly as they sit in a real home directory.
+  const real = path.join(root, '.local', 'share', 'Steam');
+  fs.mkdirSync(path.join(real, 'steamapps', 'common', 'A Game'), { recursive: true });
+  fs.mkdirSync(path.join(root, '.steam'), { recursive: true });
+  fs.symlinkSync(real, path.join(root, '.steam', 'steam'));
+
+  const viaData = path.join(real, 'steamapps', 'common', 'A Game');
+  const viaLink = path.join(root, '.steam', 'steam', 'steamapps', 'common', 'A Game');
+  assert.notEqual(path.resolve(viaData), path.resolve(viaLink), 'the two paths really are different strings');
+
+  const games = dedupe([
+    { launcher: 'Steam', id: '1', name: 'A Game', dir: viaData, poster: null },
+    { launcher: 'Steam', id: '1', name: 'A Game', dir: viaLink, poster: null }
+  ]);
+  assert.equal(games.length, 1);
+});

--- a/test/linux-launchers.test.js
+++ b/test/linux-launchers.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { heroic, lutris, yamlSection } = require('../src/library');
+
+function tree(root, files) {
+  for (const [rel, body] of Object.entries(files)) {
+    const file = path.join(root, rel);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, typeof body === 'string' ? body : JSON.stringify(body));
+  }
+}
+
+test('Heroic games are read from each store, whichever key names it uses', (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-heroic-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const root = path.join(home, '.config', 'heroic');
+  const install = (name) => {
+    const dir = path.join(home, 'Games', name);
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  };
+  const epic = install('Epic Game'), gog = install('GOG Game'), sideload = install('Sideloaded');
+  install('Native Game');
+
+  tree(root, {
+    // legendary keys its file by app name and nests nothing.
+    'legendaryConfig/legendary/installed.json': {
+      Ordinal: { app_name: 'Ordinal', title: 'Epic Game', install_path: epic, platform: 'Windows' },
+      Gone: { app_name: 'Gone', title: 'Uninstalled', install_path: path.join(home, 'Games', 'Removed') }
+    },
+    // The GOG store wraps its list, and spells the id differently.
+    'gog_store/installed.json': { installed: [
+      { appName: '1234', install_path: gog, platform: 'windows' },
+      { appName: '5678', install_path: path.join(home, 'Games', 'Native Game'), platform: 'linux' }
+    ] },
+    // A sideloaded game keeps its paths one level down.
+    'sideload_apps/library.json': { games: [
+      { app_name: 'side-1', title: 'Sideloaded', install: { install_path: sideload, platform: 'Windows' } }
+    ] }
+  });
+
+  const games = heroic({ home, env: {} });
+  assert.deepEqual(games.map((game) => game.name).sort(), ['Epic Game', 'GOG Game', 'Sideloaded']);
+  assert.deepEqual(games.map((game) => game.launcher), ['Heroic', 'Heroic', 'Heroic']);
+  // No title anywhere in the GOG store, so the folder names it.
+  assert.equal(games.find((game) => game.id === '1234').dir, gog);
+  assert.equal(games.find((game) => game.id === 'Ordinal').dir, epic);
+});
+
+test('a Flatpak Heroic keeps its own config tree and is read too', (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-heroic-flatpak-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const dir = path.join(home, 'Games', 'Flatpak Game');
+  fs.mkdirSync(dir, { recursive: true });
+  tree(path.join(home, '.var', 'app', 'com.heroicgameslauncher.hgl', 'config', 'heroic'), {
+    'legendaryConfig/legendary/installed.json': { One: { app_name: 'One', title: 'Flatpak Game', install_path: dir } }
+  });
+  assert.deepEqual(heroic({ home, env: {} }).map((game) => game.name), ['Flatpak Game']);
+});
+
+// Written exactly as PyYAML's safe_dump produces it: block style, two-space
+// indent, keys sorted, and quoting only where a value needs it.
+const LUTRIS_YML = `game:
+  arch: win64
+  exe: drive_c/GOG Games/Some Game/bin/game.exe
+  prefix: PREFIX
+  working_dir: ''
+system:
+  env:
+    DXVK_HUD: '1'
+wine:
+  dxvk: true
+  version: wine-ge-8-26
+`;
+
+test('Lutris games come from the per-game config, with a relative exe resolved against the prefix', (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-lutris-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const prefix = path.join(home, 'Games', 'some-game');
+  const nested = path.join(prefix, 'drive_c', 'GOG Games', 'Some Game', 'bin');
+  fs.mkdirSync(nested, { recursive: true });
+  const absolute = path.join(home, 'Games', 'Other');
+  fs.mkdirSync(absolute, { recursive: true });
+
+  const games = path.join(home, '.config', 'lutris', 'games');
+  tree(games, {
+    'some-game-1700000000.yml': LUTRIS_YML.replace('PREFIX', prefix),
+    'other-game-1700000001.yml': `game:\n  exe: ${path.join(absolute, 'Other.exe')}\n`,
+    // A native Linux game is listed here too and cannot take the payload.
+    'native-game-1700000002.yml': `game:\n  exe: ${path.join(absolute, 'native.sh')}\n`,
+    // The folder is gone but the config outlives it.
+    'stale-game-1700000003.yml': `game:\n  exe: ${path.join(home, 'Games', 'Removed', 'x.exe')}\n`
+  });
+
+  const found = lutris({ home, env: {} });
+  assert.deepEqual(found.map((game) => game.name).sort(), ['Other Game', 'Some Game']);
+  assert.equal(found.find((game) => game.id === 'some-game').dir, nested);
+  assert.equal(found.find((game) => game.id === 'other-game').dir, absolute);
+  assert.equal(found[0].launcher, 'Lutris');
+});
+
+test('the config reader takes one section and leaves the rest alone', () => {
+  const game = yamlSection(LUTRIS_YML.replace('PREFIX', '~/Games/x'), 'game');
+  assert.equal(game.exe, 'drive_c/GOG Games/Some Game/bin/game.exe');
+  assert.equal(game.prefix, '~/Games/x');
+  assert.equal(game.working_dir, '');
+  assert.equal(game.version, undefined, 'the wine section is not merged in');
+  assert.equal(yamlSection(LUTRIS_YML, 'wine').version, 'wine-ge-8-26');
+  assert.equal(yamlSection(LUTRIS_YML, 'system').env, undefined, 'a nested map is not a scalar');
+  // PyYAML escapes a single quote by doubling it inside a quoted scalar.
+  assert.equal(yamlSection("game:\n  exe: 'C:\\O''Brien\\game.exe'\n", 'game').exe, "C:\\O'Brien\\game.exe");
+});
+
+test('a tilde in a Lutris path is expanded against the home it was found in', (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-lutris-tilde-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const dir = path.join(home, 'Games', 'Tilde', 'bin');
+  fs.mkdirSync(dir, { recursive: true });
+  tree(path.join(home, '.config', 'lutris', 'games'), {
+    'tilde-game-1700000004.yml': 'game:\n  exe: bin/game.exe\n  prefix: ~/Games/Tilde\n'
+  });
+  assert.equal(lutris({ home, env: {} })[0].dir, dir);
+});

--- a/test/linux-launchers.test.js
+++ b/test/linux-launchers.test.js
@@ -284,3 +284,34 @@ test('one folder reached by two paths is one game, not two', linuxOnly, (t) => {
   ]);
   assert.equal(games.length, 1);
 });
+
+// A DLC's installed.json entry points at the base game's own folder and can
+// carry no executable of its own. Found via a real install: Cyberpunk 2077's
+// REDmod DLC shares the base game's install_path and precedes it in the
+// store's key order, and "REDmod" does not match dedupe's /\bdlc\b/ pattern,
+// so without this filter the DLC entry is the one that survives.
+test('a DLC entry pointing at the base game\'s folder is skipped', (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-heroic-dlc-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const dir = path.join(home, 'Games', 'BaseGame');
+  fs.mkdirSync(dir, { recursive: true });
+
+  tree(path.join(home, '.config', 'heroic'), {
+    'legendaryConfig/legendary/installed.json': {
+      // Alphabetically first, exactly as in the real installed.json.
+      '02855a2f4c044aa1a813b19f8c447fe1': {
+        app_name: '02855a2f4c044aa1a813b19f8c447fe1', title: 'Base Game - REDmod',
+        install_path: dir, is_dlc: true, executable: '', platform: 'Windows'
+      },
+      Ginger: {
+        app_name: 'Ginger', title: 'Base Game',
+        install_path: dir, is_dlc: false, executable: 'game.exe', platform: 'Windows'
+      }
+    }
+  });
+
+  const games = heroic({ home, env: {} });
+  assert.equal(games.length, 1, 'the DLC entry does not also produce a game');
+  assert.equal(games[0].id, 'Ginger');
+  assert.equal(games[0].name, 'Base Game');
+});

--- a/test/linux-proton.test.js
+++ b/test/linux-proton.test.js
@@ -230,3 +230,27 @@ test('the Feeder route is refused on Linux, and OptiScaler is left open', linuxO
   const blocked = await handlers.get('install')(event, game, target.path, 'optiscaler', 'vulkan');
   assert.equal(blocked.code, 'errExistingReShade');
 });
+
+test('a prefix without Microsoft\'s shader compiler is recognised as one that cannot run NR', linuxOnly, (t) => {
+  const { nativeShaderCompiler } = require('../src/core/proton');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-compiler-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const make = (name, size, override) => {
+    const prefix = path.join(root, name);
+    const system32 = path.join(prefix, 'drive_c', 'windows', 'system32');
+    fs.mkdirSync(system32, { recursive: true });
+    fs.writeFileSync(path.join(system32, 'd3dcompiler_47.dll'), Buffer.alloc(size));
+    fs.writeFileSync(path.join(prefix, 'user.reg'), override
+      ? '[Software\\\\Wine\\\\DllOverrides]\n"*d3dcompiler_47"="native"\n'
+      : '[Software\\\\Wine\\\\DllOverrides]\n');
+    return prefix;
+  };
+
+  // Sizes taken from two real prefixes: Wine ships 370 KB, Microsoft 4.1 MB.
+  assert.equal(nativeShaderCompiler(make('builtin', 370547, false)), false, 'Wine\'s own build');
+  assert.equal(nativeShaderCompiler(make('native-no-override', 4346120, false)), false, 'present but not preferred');
+  assert.equal(nativeShaderCompiler(make('ready', 4346120, true)), true);
+  assert.equal(nativeShaderCompiler(path.join(root, 'nope')), false, 'no prefix at all');
+  assert.equal(nativeShaderCompiler(null), false);
+});

--- a/test/linux-proton.test.js
+++ b/test/linux-proton.test.js
@@ -167,3 +167,55 @@ test('an install without a Steam Play prefix still runs, and only refuses where 
   const attempt = await configs.at(-1).setupRunner('ReShade_Setup.exe', [target.path], () => {});
   assert.equal(attempt.code, -1, 'the runner tried to spawn Proton rather than refusing');
 });
+
+test('Vulkan is refused for the Feeder route only, and left open for OptiScaler', linuxOnly, async (t) => {
+  const vm = require('vm');
+  const { createRequire } = require('module');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-vulkan-route-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const game = path.join(root, 'game');
+  fs.mkdirSync(game, { recursive: true });
+  const target = { path: path.join(game, 'Game.exe'), rel: 'Game.exe', bitness: 64, api: 'vulkan', apiLabel: 'Vulkan' };
+
+  const main = path.resolve(__dirname, '../main.js');
+  const realRequire = createRequire(main);
+  const handlers = new Map();
+  const configs = [];
+  const stubs = {
+    electron: { app: { setAppUserModelId() {}, whenReady: () => ({ then() {} }), on() {}, getPath: () => root },
+      BrowserWindow: { fromWebContents: () => ({ isDestroyed: () => false, getContentSize: () => [1280, 860] }) },
+      Menu: { buildFromTemplate: () => ({ popup() {} }) },
+      ipcMain: { handle: (name, fn) => handlers.set(name, fn) },
+      dialog: { showMessageBox: async () => ({ response: 0 }) }, clipboard: { writeText() {} } },
+    './src/library': { ...realRequire('./src/library'), steam: () => [], heroic: () => [], lutris: () => [] },
+    './src/core/scan.js': { scanGame: async () => ({ chosen: target, exeCandidates: [target], hasNativeDlss: true }) },
+    './src/core/compatibility': { assertSafeTarget() {}, hasAntiCheat: () => false },
+    './src/core/install-guards': { assertGameClosed: async () => {}, antiCheatPresent: () => false, gpuInfo: async () => [{ name: 'NVIDIA GeForce RTX 5090', driver: '616.56' }], gpuSupported: () => true },
+    './src/shared/install-routes': { nativeDlssPresent: () => true, routesFor: () => ['feeder', 'optiscaler'], recommendedRoute: () => 'feeder' },
+    './src/core/runtime-components.js': { missingVCRuntime: () => [], ensureLumenite: async () => null },
+    './src/core/optiscaler': { checkConflicts() {}, ensureOptiScaler: async () => root, RELEASE: { version: 'fixture' } },
+    './src/core/backend-manager': {
+      readManifest: () => null,
+      install: async (config) => {
+        configs.push(config);
+        return { version: 1, date: new Date().toISOString(), route: config.route, game: { dir: game, exe: 'Game.exe', api: 'vulkan' }, replaced: [], added: [] };
+      },
+      restore: async () => true
+    }
+  };
+  const context = vm.createContext({ require: (name) => stubs[name] || realRequire(name), __dirname: path.dirname(main), process, Buffer, console });
+  vm.runInContext(fs.readFileSync(main, 'utf8'), context, { filename: main });
+  vm.runInContext('payload = () => ({ source: { feeder: { ok32: true, ok64: true } } }); companionAddons = () => [];', context);
+  const event = { sender: { send() {} } };
+
+  const feeder = await handlers.get('install')(event, game, target.path, 'feeder', 'vulkan');
+  assert.equal(feeder.ok, false);
+  assert.equal(feeder.code, 'errLinuxVulkanUnsupported');
+
+  // OptiScaler puts a proxy DLL in the game folder and never registers a
+  // layer, so nothing about it depends on the Windows registry.
+  const opti = await handlers.get('install')(event, game, target.path, 'optiscaler', 'vulkan');
+  assert.equal(opti.ok, true);
+  assert.equal(configs.at(-1).route, 'optiscaler');
+  assert.equal(configs.at(-1).api, 'vulkan');
+});

--- a/test/linux-proton.test.js
+++ b/test/linux-proton.test.js
@@ -104,3 +104,66 @@ test('a wine process is tied to the game by what it has mapped, not by its own e
   assert.equal(row.ExecutablePath, library);
   await assert.rejects(guards.assertGameClosed(dir, exe), { code: 'errGameRunning' });
 });
+
+// Runs the real install handler with fake installers and a fake Steam root, to
+// check which games still reach the Windows ReShade Setup and which no longer
+// have to. No game files, GPU or real Steam library are touched.
+test('an install without a Steam Play prefix still runs, and only refuses where it reaches ReShade Setup', linuxOnly, async (t) => {
+  const vm = require('vm');
+  const { createRequire } = require('module');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-proton-gate-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const game = path.join(root, 'game');
+  fs.mkdirSync(game, { recursive: true });
+  const target = { path: path.join(game, 'Game.exe'), rel: 'Game.exe', bitness: 64, api: 'dxgi', apiLabel: 'DirectX 12' };
+
+  const main = path.resolve(__dirname, '../main.js');
+  const realRequire = createRequire(main);
+  const handlers = new Map();
+  const configs = [];
+  let steamGames = [];
+  const stubs = {
+    electron: { app: { setAppUserModelId() {}, whenReady: () => ({ then() {} }), on() {}, getPath: () => root },
+      BrowserWindow: { fromWebContents: () => ({ isDestroyed: () => false, getContentSize: () => [1280, 860] }) },
+      Menu: { buildFromTemplate: () => ({ popup() {} }) },
+      ipcMain: { handle: (name, fn) => handlers.set(name, fn) },
+      dialog: { showMessageBox: async () => ({ response: 0 }) }, clipboard: { writeText() {} } },
+    './src/library': { ...realRequire('./src/library'), steam: () => steamGames },
+    './src/core/scan.js': { scanGame: async () => ({ chosen: target, exeCandidates: [target], hasNativeDlss: true }) },
+    './src/core/compatibility': { assertSafeTarget() {}, hasAntiCheat: () => false },
+    './src/core/install-guards': { assertGameClosed: async () => {}, antiCheatPresent: () => false, gpuInfo: async () => [{}], gpuSupported: () => true },
+    './src/shared/install-routes': { nativeDlssPresent: () => true, routesFor: () => ['native'], recommendedRoute: () => 'native' },
+    './src/core/runtime-components.js': { missingVCRuntime: () => [], ensureLumenite: async () => null },
+    './src/core/optiscaler': { checkConflicts() {}, ensureOptiScaler: async () => root, RELEASE: { version: 'fixture' } },
+    './src/core/backend-manager': {
+      readManifest: () => null,
+      install: async (config) => {
+        configs.push(config);
+        return { version: 1, date: new Date().toISOString(), route: config.route, game: { dir: game, exe: 'Game.exe', api: 'dxgi' }, replaced: [], added: [] };
+      },
+      restore: async () => true
+    }
+  };
+  const context = vm.createContext({ require: (name) => stubs[name] || realRequire(name), __dirname: path.dirname(main), process, Buffer, console });
+  vm.runInContext(fs.readFileSync(main, 'utf8'), context, { filename: main });
+  vm.runInContext('payload = () => ({ source: { feeder: { ok32: true, ok64: true } } }); companionAddons = () => [];', context);
+  const event = { sender: { send() {} } };
+
+  // No prefix: the install is no longer refused before it starts, and the
+  // runner it carries is the one that gives up only when the setup is reached.
+  assert.equal((await handlers.get('install')(event, game, target.path, 'native', 'dxgi')).ok, true);
+  await assert.rejects(async () => configs.at(-1).setupRunner('ReShade_Setup.exe', [target.path], () => {}), { code: 'errProtonRequired' });
+
+  // With a prefix the game gets a runner that actually launches Proton: a
+  // missing setup comes back as a failed run, not as a refusal to try.
+  const steamRoot = path.join(root, 'Steam');
+  const prefix = path.join(steamRoot, 'steamapps', 'compatdata', '123', 'pfx');
+  fs.mkdirSync(prefix, { recursive: true });
+  fs.mkdirSync(path.join(steamRoot, 'steamapps', 'common', 'Proton 9.0'), { recursive: true });
+  fs.writeFileSync(path.join(steamRoot, 'steamapps', 'common', 'Proton 9.0', 'proton'), '');
+  steamGames = [{ launcher: 'Steam', id: '123', name: 'Example Game', dir: game, steamRoot, protonPrefix: prefix }];
+
+  assert.equal((await handlers.get('install')(event, game, target.path, 'native', 'dxgi')).ok, true);
+  const attempt = await configs.at(-1).setupRunner('ReShade_Setup.exe', [target.path], () => {});
+  assert.equal(attempt.code, -1, 'the runner tried to spawn Proton rather than refusing');
+});

--- a/test/linux-proton.test.js
+++ b/test/linux-proton.test.js
@@ -129,7 +129,7 @@ test('an install without a Steam Play prefix still runs, and only refuses where 
       ipcMain: { handle: (name, fn) => handlers.set(name, fn) },
       dialog: { showMessageBox: async () => ({ response: 0 }) }, clipboard: { writeText() {} } },
     './src/library': { ...realRequire('./src/library'), steam: () => steamGames },
-    './src/core/scan.js': { scanGame: async () => ({ chosen: target, exeCandidates: [target], hasNativeDlss: true }) },
+    './src/core/scan.js': { scanGame: async () => ({ chosen: target, exeCandidates: [target], hasNativeDlss: true, reshade: { installed: false, file: null, kind: null, version: null, addonSupport: false } }) },
     './src/core/compatibility': { assertSafeTarget() {}, hasAntiCheat: () => false },
     './src/core/install-guards': { assertGameClosed: async () => {}, antiCheatPresent: () => false, gpuInfo: async () => [{}], gpuSupported: () => true },
     './src/shared/install-routes': { nativeDlssPresent: () => true, routesFor: () => ['native'], recommendedRoute: () => 'native' },
@@ -168,7 +168,7 @@ test('an install without a Steam Play prefix still runs, and only refuses where 
   assert.equal(attempt.code, -1, 'the runner tried to spawn Proton rather than refusing');
 });
 
-test('Vulkan is refused for the Feeder route only, and left open for OptiScaler', linuxOnly, async (t) => {
+test('the Feeder route is refused on Linux, and OptiScaler is left open', linuxOnly, async (t) => {
   const vm = require('vm');
   const { createRequire } = require('module');
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-vulkan-route-'));
@@ -181,6 +181,7 @@ test('Vulkan is refused for the Feeder route only, and left open for OptiScaler'
   const realRequire = createRequire(main);
   const handlers = new Map();
   const configs = [];
+  let reshade = { installed: false, file: null, kind: null, version: null, addonSupport: false };
   const stubs = {
     electron: { app: { setAppUserModelId() {}, whenReady: () => ({ then() {} }), on() {}, getPath: () => root },
       BrowserWindow: { fromWebContents: () => ({ isDestroyed: () => false, getContentSize: () => [1280, 860] }) },
@@ -188,7 +189,7 @@ test('Vulkan is refused for the Feeder route only, and left open for OptiScaler'
       ipcMain: { handle: (name, fn) => handlers.set(name, fn) },
       dialog: { showMessageBox: async () => ({ response: 0 }) }, clipboard: { writeText() {} } },
     './src/library': { ...realRequire('./src/library'), steam: () => [], heroic: () => [], lutris: () => [] },
-    './src/core/scan.js': { scanGame: async () => ({ chosen: target, exeCandidates: [target], hasNativeDlss: true }) },
+    './src/core/scan.js': { scanGame: async () => ({ chosen: target, exeCandidates: [target], hasNativeDlss: true, reshade }) },
     './src/core/compatibility': { assertSafeTarget() {}, hasAntiCheat: () => false },
     './src/core/install-guards': { assertGameClosed: async () => {}, antiCheatPresent: () => false, gpuInfo: async () => [{ name: 'NVIDIA GeForce RTX 5090', driver: '616.56' }], gpuSupported: () => true },
     './src/shared/install-routes': { nativeDlssPresent: () => true, routesFor: () => ['feeder', 'optiscaler'], recommendedRoute: () => 'feeder' },
@@ -208,9 +209,13 @@ test('Vulkan is refused for the Feeder route only, and left open for OptiScaler'
   vm.runInContext('payload = () => ({ source: { feeder: { ok32: true, ok64: true } } }); companionAddons = () => [];', context);
   const event = { sender: { send() {} } };
 
-  const feeder = await handlers.get('install')(event, game, target.path, 'feeder', 'vulkan');
-  assert.equal(feeder.ok, false);
-  assert.equal(feeder.code, 'errLinuxVulkanUnsupported');
+  // The Feeder is refused whatever the renderer: it can leave a Proton game
+  // unable to start, which is not something an API check would catch.
+  for (const api of ['vulkan', 'dxgi']) {
+    const feeder = await handlers.get('install')(event, game, target.path, 'feeder', api);
+    assert.equal(feeder.ok, false);
+    assert.equal(feeder.code, 'errLinuxFeederUnsupported');
+  }
 
   // OptiScaler puts a proxy DLL in the game folder and never registers a
   // layer, so nothing about it depends on the Windows registry.
@@ -218,4 +223,10 @@ test('Vulkan is refused for the Feeder route only, and left open for OptiScaler'
   assert.equal(opti.ok, true);
   assert.equal(configs.at(-1).route, 'optiscaler');
   assert.equal(configs.at(-1).api, 'vulkan');
+
+  // A proxy that is already there may belong to another mod; replacing it
+  // crashed otherwise healthy games.
+  reshade = { installed: true, file: 'dxgi.dll', kind: 'proxy', version: '6.0.0', addonSupport: false };
+  const blocked = await handlers.get('install')(event, game, target.path, 'optiscaler', 'vulkan');
+  assert.equal(blocked.code, 'errExistingReShade');
 });

--- a/test/linux-proton.test.js
+++ b/test/linux-proton.test.js
@@ -40,3 +40,67 @@ test('configured Proton tool is preferred for a Steam prefix', (t) => {
   fs.writeFileSync(path.join(path.dirname(prefix), 'config_info'), 'Proton 9.0');
   assert.equal(protonCandidates(root, prefix)[0], path.join(root, 'steamapps', 'common', 'Proton 9.0', 'proton'));
 });
+
+const guards = require('../src/core/install-guards');
+const { spawn } = require('child_process');
+const { once } = require('events');
+const linuxOnly = { skip: process.platform !== 'linux' ? 'Linux only' : false };
+
+test('a process running from the game folder blocks the install, and stops blocking once it exits', linuxOnly, async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-guard-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const exe = path.join(dir, 'Game.exe');
+  fs.writeFileSync(exe, '');
+
+  // Steam launches a Proton game with the game folder as its working
+  // directory, which is what this stands in for.
+  const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 30000)'], { cwd: dir, stdio: 'ignore' });
+  t.after(() => { try { child.kill(); } catch {} });
+  await once(child, 'spawn');
+  await assert.rejects(guards.assertGameClosed(dir, exe), { code: 'errGameRunning' });
+
+  child.kill();
+  await once(child, 'exit');
+  await guards.assertGameClosed(dir, exe);
+});
+
+test('the /proc snapshot names processes and ties none of them to an unrelated folder', linuxOnly, () => {
+  const rows = guards.linuxSnapshot(path.join(os.tmpdir(), 'dlss5-no-such-game'));
+  const self = rows.find((row) => row.ProcessId === process.pid);
+  assert.ok(self, 'the running test process is in the snapshot');
+  assert.equal(self.Name, path.basename(process.execPath));
+  assert.equal(guards.matchingProcesses(rows, path.join(os.tmpdir(), 'dlss5-no-such-game'), 'Game.exe').length, 0);
+});
+
+test('an unreadable process table is a failed check rather than an idle machine', linuxOnly, async () => {
+  await assert.rejects(guards.assertGameClosed('/nonexistent', 'Game.exe', () => { throw new Error('EACCES'); }), { code: 'errProcessCheck' });
+});
+
+test('the GPU query uses the Linux nvidia-smi binary', linuxOnly, async () => {
+  let called = null;
+  const rows = await guards.gpuInfo((file, args) => { called = { file, args }; return 'NVIDIA GeForce RTX 5090, 616.56'; });
+  assert.equal(called.file, 'nvidia-smi');
+  assert.deepEqual(rows, [{ name: 'NVIDIA GeForce RTX 5090', driver: '616.56' }]);
+  assert.equal(guards.gpuSupported(rows), true);
+});
+
+test('a wine process is tied to the game by what it has mapped, not by its own exe path', linuxOnly, async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-maps-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const exe = path.join(dir, 'Game.exe');
+  fs.writeFileSync(exe, '');
+
+  // Stands in for a Proton game: the process runs from outside the folder and
+  // its /proc/<pid>/exe points at the runtime, exactly as wine's does. The
+  // only tie left is the library it loaded out of the game folder.
+  const library = path.join(dir, 'game.so');
+  fs.copyFileSync(fs.realpathSync('/usr/lib/libz.so.1'), library);
+  const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 30000)', 'Game.exe'],
+    { cwd: os.tmpdir(), stdio: 'ignore', env: { ...process.env, LD_PRELOAD: library } });
+  t.after(() => { try { child.kill(); } catch {} });
+  await once(child, 'spawn');
+
+  const row = guards.linuxSnapshot(dir).find((entry) => entry.ProcessId === child.pid);
+  assert.equal(row.ExecutablePath, library);
+  await assert.rejects(guards.assertGameClosed(dir, exe), { code: 'errGameRunning' });
+});

--- a/test/scan-architecture.test.js
+++ b/test/scan-architecture.test.js
@@ -194,3 +194,19 @@ test('Assassins Creed Black Flag selects the 32-bit single-player executable', a
   assert.equal(scan.chosen.api, 'dxgi');
   assert.equal(scan.chosen.apiLabel, 'DirectX 11');
 });
+
+// A name that ends in "launcher" is one too. The Feeder patching these instead
+// of the game is what left Proton titles unable to start.
+// Found by Febsho — https://github.com/Febsho/DLSS5-Swapper-Linux
+test('launcher-suffixed executables are never selected as game targets', async (t) => {
+  const gameDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-launcher-'));
+  t.after(() => fs.rmSync(gameDir, { recursive: true, force: true }));
+  const launcher = path.join(gameDir, 'Game', 'Launcher', 'MassEffectLauncher.exe');
+  const game = path.join(gameDir, 'Game', 'ME1', 'Binaries', 'Win64', 'MassEffect1.exe');
+  minimalPe(launcher, { bitness: 64, marker: 'D3D12CreateDevice' });
+  minimalPe(game, { bitness: 64, marker: 'D3D12CreateDevice' });
+
+  const scan = await scanGame(gameDir);
+  assert.equal(scan.exeCandidates.some((item) => item.path === launcher), false);
+  assert.equal(scan.chosen.path, game);
+});

--- a/test/vulkan-layer.test.js
+++ b/test/vulkan-layer.test.js
@@ -38,3 +38,25 @@ test('Vulkan layer stays registered until the last emulator is restored', async 
   assert.equal(await layer.detach(second, path.join(root, 'Cemu'), runner), true);
   assert.equal(values.size, 0);
 });
+
+test('without a host registry the layer is refused before anything is written', { skip: process.platform === 'win32' ? 'not Windows' : false }, async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-vulkan-host-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const sourceDir = path.join(root, 'source');
+  const targetDir = path.join(root, 'installed');
+  fs.mkdirSync(sourceDir, { recursive: true });
+  for (const bits of [64, 32]) {
+    fs.writeFileSync(path.join(sourceDir, `ReShade${bits}.dll`), `dll${bits}`);
+    fs.writeFileSync(path.join(sourceDir, `ReShade${bits}.json`), JSON.stringify({ layer: { name: 'VK_LAYER_reshade' } }));
+  }
+
+  // Nothing has registered a layer where no registry is reachable.
+  assert.equal(await layer.existing(layer.defaultRunner), null);
+
+  await assert.rejects(
+    layer.register({ sourceDir, targetDir, gameDir: path.join(root, 'RPCS3') }),
+    { code: 'errVulkanLayerUnsupported' }
+  );
+  // The DLLs must not be lying around after a refusal.
+  assert.equal(fs.existsSync(targetDir), false);
+});


### PR DESCRIPTION
Continues the Linux work from #25. That PR made Steam Play games discoverable and could run ReShade Setup in a game's Proton prefix; this one makes an install on Linux actually reach the end, and adds Heroic and Lutris.

Each commit stands alone and explains itself, so this is readable one at a time.

## What was blocking

**`assertGameClosed` shelled out to PowerShell**, so on Linux it threw `errProcessCheck` and stopped every install before it began. The process snapshot is now behind a platform switch: Windows keeps the `Get-CimInstance` query, Linux reads `/proc`. A Proton game is a wine process, so `/proc/<pid>/exe` points into the Proton runtime and never at the game — what ties one to a folder is the working directory Steam launches it with, a `Z:` path in its argv, and the `.exe` and DLLs it keeps mapped. `gpuInfo` also asked for `nvidia-smi.exe`.

**The Proton prefix was an entry condition.** Most of an install does not need one: copying DLSS DLLs and writing configs is ordinary file IO, the OptiScaler route runs no executable at all, and a game that already carries an add-on ReShade returns before the setup is reached. The installer is now handed a setup runner that refuses with `errProtonRequired` at the point the setup is actually invoked — a path `installReShadeAt` already handles, writing a recoverable checkpoint and rethrowing so the journal rolls back. Finding the prefix also compares realpaths now; Steam's two data roots are symlinks to one another, so the same game turns up under either path and the string compare missed whichever one the renderer did not send.

**Vulkan was refused outright**, which is only true of the Feeder route. OptiScaler reaches Vulkan through a proxy DLL in the game folder and touches no registry, so it is allowed through.

## What is new

**Heroic and Lutris.** Heroic keeps one plain-JSON file per store — the four paths were read out of the shipped app rather than guessed, and each entry is read through whichever key spelling is present, since the stores disagree and Heroic has moved them between versions. Lutris keeps the install directory in a SQLite database that would need a driver this app does not ship, and `lutris --list-games --json` takes 3.4s on an empty library against the 2ms the whole scan currently costs, so the per-game YAML beside the database is parsed instead — only PyYAML's block style, which is what Lutris writes. Both cover a distro package and a Flatpak.

**ReShade Setup in a Heroic or Lutris prefix.** A context is now the command, the arguments before the program, and the environment, which is all Steam Play and the wine launchers differ in. Heroic's prefix and wine build come from `GamesConfig/<app>.json` falling back to `defaultSettings`; Lutris' wine version resolves to a downloaded runner, a system install, or a custom path.

Also fixes a leak in `createSetupRunner`: the kill timer was never cleared, holding the event loop open for two minutes after every setup that finished on its own.

## The Vulkan layer

I checked whether the implicit layer could be registered inside the prefix instead. It cannot: `ImplicitLayers` appears nowhere in the Wine tree (11.16), and `winevulkan`'s only layer symbols are the enumeration thunks that forward to the host loader, which loads `.so` layers and would never load a Windows ReShade DLL. Writing that key would produce a silently broken install, so `vulkan-layer.js` now says so instead — `register()` used to throw only after copying the DLLs into place, on a missing `reg.exe`, reporting an empty message. The check is on whether the default runner is in use rather than on the platform, so a caller supplying its own registry is unaffected.

## Tests

102 pass, up from 84. New coverage is Linux-gated and includes real integration rather than only fixtures: a child process started in a game folder is detected and stops being detected once it exits; a process outside the folder that has mapped a library from inside it is caught through `/proc/<pid>/maps`; a fake wine binary confirms the runner spawns it with `WINEPREFIX` set and the arguments in order. The Lutris fixtures are literal `yaml.safe_dump` output.

The `history-ipc` test was failing on Linux before this branch, on unmodified `main` — it was the blanket Proton gate. It passes now.

## What I could not verify

**None of this has been run against a real installed game.** I have no Proton prefix, no Heroic or Lutris library, and no payload on the machine I wrote it on. File locations and the environment each launcher uses were read out of Heroic's and Lutris' own shipped code, and behaviour is covered by tests, but the end-to-end path is untried — worth saying plainly before you merge.

One thing I deliberately left alone: `gpuSupported` compares the NVIDIA driver against `616.56` in Windows numbering, and the Linux driver does not use the same scheme. I had no basis for a mapping and did not want to invent one, so the threshold is unchanged and noted in the README.
