### PR TITLE
Detect Kingdom Come: Deliverance II through its WHGame.dll renderer

### DIFF
--- a/main.js
+++ b/main.js
@@ -189,7 +189,7 @@ const posterDir = () => path.join(app.getPath('userData'), 'posters');
 const keyFor = (dir) => crypto.createHash('sha1').update(path.resolve(dir).toLowerCase()).digest('hex').slice(0, 16);
 // Bump when scan metadata or detection changes so an old wrong result is not
 // kept forever merely because the folder was scanned by an earlier release.
-const SCAN_RULES = 6;
+const SCAN_RULES = 7;
 
 function loadState() {
   try {

--- a/src/core/scan.js
+++ b/src/core/scan.js
@@ -259,7 +259,8 @@ function detectEngineApi(file) {
     'left4dead2.exe': ['bin/shaderapidx9.dll', 'bin/engine.dll'],
     'killingfloor.exe': ['D3D9Drv.dll', 'D3DDrv.dll', 'OpenGLDrv.dll'],
     'farcry5.exe': ['FC_m64.dll'],
-    'watch_dogs.exe': ['Disrupt_b64.dll']
+    'watch_dogs.exe': ['Disrupt_b64.dll'],
+    'kingdomcome.exe': ['WHGame.dll']
   }[path.basename(file).toLowerCase()];
   if (!modules) return null;
   const bitness = pe.getBitness(file);

--- a/test/compatibility-regressions.test.js
+++ b/test/compatibility-regressions.test.js
@@ -24,7 +24,8 @@ test('small Source, GoldSrc, UE2 and Ubisoft dispatchers use actual engine-modul
     ['hl.exe', 'hw.dll', 32, 'wglCreateContext', 'opengl'],
     ['KillingFloor.exe', 'System/D3D9Drv.dll', 32, 'Direct3DCreate9', 'd3d9'],
     ['FarCry5.exe', 'bin/FC_m64.dll', 64, 'D3D11CreateDevice', 'dxgi'],
-    ['Watch_Dogs.exe', 'bin/Disrupt_b64.dll', 64, 'D3D11CreateDevice', 'dxgi']
+    ['Watch_Dogs.exe', 'bin/Disrupt_b64.dll', 64, 'D3D11CreateDevice', 'dxgi'],
+    ['KingdomCome.exe', 'WHGame.dll', 64, 'D3D12CreateDevice', 'dxgi']
   ]) {
     const dir = path.join(root, name);
     const nested = /Killing|FarCry|Watch/.test(name) ? path.dirname(module) : '';


### PR DESCRIPTION
KingdomCome.exe is a thin launcher: its import table names only ntdll, kernel32, user32, shell32, ole32 and the CRT, and no Direct3D entry point survives as a string. The renderer lives in WHGame.dll, which the launcher loads at run time, so it is absent from the import table and the sibling module walk never reaches it.

With no API evidence the executable is dropped, scanGame returns no candidate at all, and the game is listed with emptyReason 'no-exe' and nothing to install onto. The per-game rendering API override cannot recover it either, because it requires an executable that is already a candidate.

detectEngineApi exists for exactly this shape, so name the module there. The same entry serves Kingdom Come: Deliverance I, whose launcher shares the executable name and whose WHGame.dll reports Direct3D 11.

Bump SCAN_RULES with it. A card renders from the cached scan in library.json whenever its rules match, so anyone who already scanned the game keeps the stale 'no-exe' result and never sees the fix until they rescan by hand.

Verified against a retail Steam install with 2.2.1: before, chosen was null; after, KingdomCome.exe is chosen as DirectX 12, 64-bit, via engine-module:WHGame.dll.