### PR TITLE
Fix: in-game overlay never receives frames on a scaled desktop

### DIFF
--- a/scripts/probe-overlay-surface.js
+++ b/scripts/probe-overlay-surface.js
@@ -1,0 +1,65 @@
+'use strict';
+// Diagnostic: mirrors src/overlay-bridge.js exactly, including the `ready` gate,
+// so the frames it reports are the frames the app would actually transmit.
+// Paints before `ready` are ignored by the app and are shown only for contrast.
+//
+//   npx electron scripts/probe-overlay-surface.js
+const { app, BrowserWindow, screen } = require('electron');
+const path = require('path');
+const protocol = require('../src/overlay-protocol');
+const root = path.join(__dirname, '..');
+
+app.whenReady().then(async () => {
+  console.log('--- display ---');
+  for (const d of screen.getAllDisplays())
+    console.log(`  ${d.size.width}x${d.size.height} scaleFactor=${d.scaleFactor}` +
+                (d.scaleFactor !== 1 ? '   <-- not 100%' : ''));
+
+  const win = new BrowserWindow({ show: false, width: protocol.WIDTH, height: 900, transparent: true, frame: false,
+    webPreferences: { preload: path.join(root, 'overlay-preload.js'), offscreen: true, contextIsolation: true,
+                      sandbox: true, nodeIntegration: false, backgroundThrottling: false, spellcheck: false } });
+
+  let ready = false, pre = 0, post = 0;
+  win.webContents.on('paint', (_e, _d, image) => {
+    const { width, height } = image.getSize();
+    if (!ready) {
+      if (++pre === 1) console.log(`--- pre-ready paint (app ignores these): ${width}x${height} ---`);
+      return;
+    }
+    if (++post > 2) return;
+    const bytes = image.toBitmap().length;
+    console.log(`--- POST-READY paint #${post}  (these are the real frames) ---`);
+    console.log(`  getSize : ${width} x ${height}`);
+    console.log(`  bitmap  : ${bytes} bytes (w*h*4 = ${width * height * 4})`);
+    console.log(`  width == ${protocol.WIDTH} ? ${width === protocol.WIDTH ? 'OK - emulation fixed it' : 'MISMATCH - app drops this frame'}`);
+
+    if (post === 1) {
+      // Does a straight resample give the bridge something it will accept?
+      try {
+        const target = Math.round(height * protocol.WIDTH / width);
+        const scaled = image.resize({ width: protocol.WIDTH, height: target, quality: 'good' });
+        const s = scaled.getSize(), sb = scaled.toBitmap().length;
+        console.log(`--- resize() test ---`);
+        console.log(`  asked for ${protocol.WIDTH}x${target} -> got ${s.width}x${s.height}, ${sb} bytes (w*h*4 = ${s.width * s.height * 4})`);
+        console.log(`  usable as a fix ? ${s.width === protocol.WIDTH && sb === s.width * s.height * 4 ? 'YES' : 'NO'}`);
+      } catch (e) { console.log('  resize() threw:', e.message); }
+    }
+    if (post === 2) app.exit(0);
+  });
+
+  win.webContents.setFrameRate(30);
+  await win.loadFile(path.join(root, 'src/renderer/overlay-panel.html'));
+  const height = Math.ceil(await win.webContents.executeJavaScript(
+    `document.querySelector('#panel').getBoundingClientRect().height`));
+  console.log(`--- panel CSS height: ${height} ---`);
+  win.setContentSize(protocol.WIDTH, height);
+  win.webContents.enableDeviceEmulation({ screenPosition: 'desktop', screenSize: { width: protocol.WIDTH, height },
+    deviceScaleFactor: 1, viewSize: { width: protocol.WIDTH, height }, viewPosition: { x: 0, y: 0 }, scale: 1 });
+  ready = true;
+  win.webContents.invalidate();
+
+  setTimeout(() => {
+    console.log(post ? '' : '\nRESULT: no post-ready paints in 12s - emulation may have stopped repaints entirely.');
+    app.exit(post ? 0 : 2);
+  }, 12000);
+});

--- a/src/overlay-bridge.js
+++ b/src/overlay-bridge.js
@@ -16,6 +16,9 @@ module.exports = async function startOverlayBridge({ BrowserWindow, userData }) 
   const profile = path.basename(userData);
   const pipeName = `\\\\.\\pipe\\${profile}-overlay-${token}`;
   let latest = null, sequence = 0, client = null, closed = false, ready = false;
+  // CSS height of the panel, and the height every transmitted frame carries, so
+  // the add-on's pointer coordinates map 1:1 onto the offscreen window.
+  let panelHeight = 0;
   let server = null;
   let runtimeStatus = null, commandTime = 0, commandCount = 0;
   const win = new BrowserWindow({ show: false, width: protocol.WIDTH, height: 900, transparent: true, frame: false,
@@ -30,6 +33,7 @@ module.exports = async function startOverlayBridge({ BrowserWindow, userData }) 
   ipcMain.on('lab-overlay-control', control);
   const resize = (event, height) => {
     if (closed || event.sender !== win.webContents || !Number.isInteger(height) || height < 200 || height > protocol.MAX_HEIGHT) return;
+    panelHeight = height;
     win.setContentSize(protocol.WIDTH, height);
     win.webContents.enableDeviceEmulation({ screenPosition: 'desktop', screenSize: { width: protocol.WIDTH, height }, deviceScaleFactor: 1, viewSize: { width: protocol.WIDTH, height }, viewPosition: { x: 0, y: 0 }, scale: 1 });
     win.webContents.invalidate();
@@ -44,11 +48,61 @@ module.exports = async function startOverlayBridge({ BrowserWindow, userData }) 
     client.sequence = latest.readUInt32LE(8);
     client.write(latest);
   }
+  // Chromium renders the offscreen panel at the display's device pixel ratio.
+  // enableDeviceEmulation fixes the CSS layout but NOT the surface it hands back,
+  // so on a scaled desktop (125%, 150%, ...) every frame arrives wider than the
+  // fixed transport width and used to be discarded in silence: the add-on then
+  // connected and waited forever on its "shared panel design" message. Resample
+  // back to the transport size instead, and keep the panel's CSS height as the
+  // target so pointer coordinates still map 1:1.
+  function box(src, sw, sh, dw, dh) {
+    if (src.length !== sw * sh * 4) return null;
+    const out = Buffer.allocUnsafe(dw * dh * 4), xr = sw / dw, yr = sh / dh;
+    for (let y = 0; y < dh; ++y) {
+      const y0 = Math.floor(y * yr), y1 = Math.min(sh, Math.max(y0 + 1, Math.ceil((y + 1) * yr)));
+      for (let x = 0; x < dw; ++x) {
+        const x0 = Math.floor(x * xr), x1 = Math.min(sw, Math.max(x0 + 1, Math.ceil((x + 1) * xr)));
+        let b = 0, g = 0, r = 0, a = 0, n = 0;
+        for (let sy = y0; sy < y1; ++sy) {
+          let i = (sy * sw + x0) * 4;
+          for (let sx = x0; sx < x1; ++sx, i += 4) { b += src[i]; g += src[i + 1]; r += src[i + 2]; a += src[i + 3]; ++n; }
+        }
+        // Averaging premultiplied BGRA is correct; protocol.frame un-multiplies.
+        const o = (y * dw + x) * 4;
+        out[o] = (b / n + 0.5) | 0; out[o + 1] = (g / n + 0.5) | 0;
+        out[o + 2] = (r / n + 0.5) | 0; out[o + 3] = (a / n + 0.5) | 0;
+      }
+    }
+    return out;
+  }
+  let paintWarned = false;
+  const refuse = message => { if (!paintWarned) { paintWarned = true; console.error('Lab overlay: dropping panel frames. ' + message); } };
+  function surfaceBitmap(image) {
+    const { width, height } = image.getSize();
+    if (!width || !height) return null;                       // transient empty frame
+    const target = panelHeight || Math.round(height * protocol.WIDTH / width);
+    if (target < 1 || target > protocol.MAX_HEIGHT) { refuse(`Panel height ${target} is outside the transport range.`); return null; }
+    if (width === protocol.WIDTH && height === target) {
+      const bitmap = image.toBitmap();
+      if (bitmap.length === width * height * 4) return { bitmap, height: target };
+    }
+    // Chromium's own resampler first; it is not obliged to honour the request.
+    const scaled = image.resize({ width: protocol.WIDTH, height: target, quality: 'good' });
+    const size = scaled.getSize(), bitmap = scaled.toBitmap();
+    if (size.width === protocol.WIDTH && size.height === target && bitmap.length === protocol.WIDTH * target * 4)
+      return { bitmap, height: target };
+    const boxed = box(image.toBitmap(), width, height, protocol.WIDTH, target);
+    if (boxed) return { bitmap: boxed, height: target };
+    refuse(`Offscreen surface ${width}x${height} could not be resampled to ${protocol.WIDTH}x${target}.`);
+    return null;
+  }
   win.webContents.on('paint', (_event, _dirty, image) => {
     if (!ready || closed) return;
-    const { width, height } = image.getSize();
-    if (width !== protocol.WIDTH || height > protocol.MAX_HEIGHT) return;
-    latest = protocol.frame(image.toBitmap(), width, height, ++sequence);
+    const surface = surfaceBitmap(image);
+    if (!surface) return;
+    try { latest = protocol.frame(surface.bitmap, protocol.WIDTH, surface.height, ++sequence); }
+    catch (error) { return refuse(error.message); }
+    paintWarned = false;
     sendLatest();
   });
   function close() {
@@ -68,6 +122,7 @@ module.exports = async function startOverlayBridge({ BrowserWindow, userData }) 
   preferences.events.on('change',preferenceChanged);
   const height = Math.ceil(await win.webContents.executeJavaScript(`document.querySelector('#panel').getBoundingClientRect().height`));
   if (height < 1 || height > protocol.MAX_HEIGHT) { win.destroy(); throw Error('Overlay panel height exceeds its bounded surface'); }
+  panelHeight = height;
   win.setContentSize(protocol.WIDTH, height);
   // Fixed CSS pixels regardless of desktop DPI. No scaling/reflow in the native UI.
   win.webContents.enableDeviceEmulation({ screenPosition: 'desktop', screenSize: { width: protocol.WIDTH, height }, deviceScaleFactor: 1, viewSize: { width: protocol.WIDTH, height }, viewPosition: { x: 0, y: 0 }, scale: 1 });


### PR DESCRIPTION
## Problem

On any desktop scaled above 100%, the in-game overlay connects to the bridge and then sits on **"DLSS 5 Swapper must remain open. Waiting for the shared panel design (one test game at a time)..."** forever. The hotkey works, the panel opens, the pipe is healthy — no frame ever arrives.

Chromium renders the offscreen panel at the display's device pixel ratio. `enableDeviceEmulation({ deviceScaleFactor: 1 })` fixes the CSS layout but has no effect on the surface handed to the `paint` handler. At 150% on a 2560x1440 display the surface is **803x1350**, where `protocol.WIDTH` requires exactly **534**.

The paint handler compared the two and returned:

```js
const { width, height } = image.getSize();
if (width !== protocol.WIDTH || height > protocol.MAX_HEIGHT) return;
```

Every frame was discarded in silence. Nothing was logged on either side, and the add-on's single waiting message is identical for a bridge that never connected, so there was nothing to go on. This affects most 1440p and 4K users, where 125%/150% is the Windows default.

## Fix

Resample the surface to the transport width instead of dropping it, targeting the panel's **CSS** height so the add-on's pointer coordinates keep mapping 1:1 onto the offscreen window (using the surface's own aspect ratio instead drifts a couple of pixels and misaligns clicks near the bottom).

- `nativeImage.resize()` is tried first and its result **verified** — it isn't obliged to honour the request when the source carries a scale factor.
- A box filter over premultiplied BGRA is the fallback. Averaging in premultiplied space is correct; `protocol.frame` un-multiplies afterwards.
- The transient `0x0` surface Chromium emits before the first real paint is ignored rather than mishandled.
- A refused frame now logs once with its real dimensions instead of vanishing.

No protocol or add-on change: frames still go out as exactly `534 x <CSS height>`, so **already-installed `.addon64` builds work unmodified** — no rebuild, no reinstall across game folders.

## Verification

`scripts/probe-overlay-surface.js` reproduces just the offscreen surface, mirroring the bridge's `ready` gate, and reports which constraint fails:

```
npx electron scripts/probe-overlay-surface.js
```

Before, on 2560x1440 @ 150%:

```
--- display ---
  2560x1440 scaleFactor=1.5   <-- not 100%
--- POST-READY paint #1 ---
  getSize : 803 x 1350
  width == 534 ? MISMATCH - app drops this frame
```

After the fix the panel renders and is fully interactive in game (verified at 150%, DX12).

## Note

I also have a change that makes the add-on report *why* it is waiting — app closed, wrong `%APPDATA%` profile, stale endpoint, refused pipe, or a frame it can't decode all currently produce that one identical message. It's `overlay.cpp` only and would have turned this into a 30-second diagnosis. I've left it out of this PR because I could only compile-check it against a stub harness, never against the real ReShade SDK. Happy to open it separately if you want it.
