### PR TITLE
Find Xbox games without switching on all-drive scanning

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -40,6 +40,19 @@ function regKeys(key) {
   }
 }
 
+// Every value of one name below a key, however deep. reg.exe costs a process
+// per call, so a tree that is several keys deep is read in one recursive query
+// rather than walked a level at a time.
+function regSearch(key, value) {
+  try {
+    const out = registryRunner(['query', key, '/s', '/v', value]);
+    return [...out.matchAll(new RegExp('^\\s+' + value + '\\s+REG_\\w+\\s+(.+)$', 'gim'))]
+      .map((m) => m[1].trim());
+  } catch {
+    return [];
+  }
+}
+
 // Valve's KeyValues format is regular enough to read with one pattern.
 const kv = (text, key) => (text.match(new RegExp(`"${key}"\\s+"([^"]+)"`, 'i')) || [])[1];
 
@@ -269,6 +282,148 @@ function folder(root, label = 'My folders', onlyGames = false) {
     .map((e) => ({ launcher: label, id: null, name: e.name, dir: path.join(root, e.name), poster: null }));
 }
 
+// ---------- Xbox app / Microsoft Store ----------
+// The Xbox app records its library in two places, and both are read because
+// each covers a case the other misses. Every drive it installs to carries a
+// `.GamingRoot` marker naming the games folder on that drive, usually
+// `XboxGames`, whose children are the games. Gaming Services also records each
+// package under PackageRepository\Root, pointing into `WindowsApps` - a
+// junction back into the same install, which finds a game whose drive marker
+// has gone missing.
+
+// "RGBX", a version, then the folder as UTF-16 with a terminating null.
+function gamingRootFolder(drive) {
+  let buf;
+  try { buf = fs.readFileSync(path.join(drive, '.GamingRoot')); } catch { return null; }
+  if (buf.length < 10 || buf.toString('latin1', 0, 4) !== 'RGBX') return null;
+  const decoded = buf.toString('utf16le', 8);
+  const end = decoded.indexOf('\0');
+  const relative = (end === -1 ? decoded : decoded.slice(0, end)).trim();
+  if (!relative) return null;
+  const dir = path.resolve(drive, relative);
+  return fs.existsSync(dir) ? dir : null;
+}
+
+// A game holds `Content`; its siblings - `GameSave` above all - do not.
+function isXboxGameFolder(dir) {
+  const content = path.join(dir, 'Content');
+  let stat;
+  try { stat = fs.statSync(content); } catch { return false; }
+  return stat.isDirectory() &&
+    (fs.existsSync(path.join(content, 'MicrosoftGame.config')) || holdsGame(content, 1));
+}
+
+const CONFIGS = (dir) => [path.join(dir, 'Content', 'MicrosoftGame.config'),
+  path.join(dir, 'MicrosoftGame.config')];
+
+function readConfig(dir, pattern) {
+  for (const config of CONFIGS(dir)) {
+    let text;
+    try { text = fs.readFileSync(config, 'utf8'); } catch { continue; }
+    const found = (text.match(pattern) || [])[1];
+    if (found) return found.trim();
+  }
+  return null;
+}
+
+// The folder has had the characters Windows forbids stripped out of it -
+// "Magic- Olden Era" - while the config keeps the title the store shows. A
+// name deferred to the package's resource table cannot be read from here.
+function xboxDisplayName(dir) {
+  const name = readConfig(dir, /DefaultDisplayName\s*=\s*"([^"]+)"/i);
+  return name && !/^ms-resource:/i.test(name) ? name : null;
+}
+
+// Mintrocket.DaveTheDiver_1.0.145.0_x64__mnyz31d5jqk06 -> Dave The Diver.
+const PACKAGE_FOLDER = /^[^_]+_\d[\d.]*_[^_]*__[^_]+$/;
+function nameFromPackage(folder) {
+  const identity = folder.split('_')[0].split('.').pop() || folder;
+  return identity.replace(/([a-z0-9])([A-Z])/g, '$1 $2').trim();
+}
+
+// "Mintrocket.DaveTheDiver" - the name both routes agree on. Comparing paths
+// cannot tell they reached the same game, because the junction that joins
+// those paths is not always resolvable.
+function xboxIdentity(dir) {
+  const identity = readConfig(dir, /<Identity\b[^>]*\bName\s*=\s*"([^"]+)"/i);
+  if (identity) return identity;
+  const folder = path.basename(dir);
+  return PACKAGE_FOLDER.test(folder) ? folder.split('_')[0] : null;
+}
+
+// One recursive read: every package sits at the bottom of the repository.
+function xboxPackageRoots() {
+  const roots = [];
+  for (const raw of regSearch('HKLM\\SOFTWARE\\Microsoft\\GamingServices\\PackageRepository\\Root', 'Root')) {
+    // Written as an extended-length path, which nothing else here expects.
+    const dir = raw.replace(/^\\\\\?\\/, '').replace(/[\\/]+$/, '');
+    if (dir && fs.existsSync(dir)) roots.push(dir);
+  }
+  return roots;
+}
+
+// Out of `WindowsApps` and back to the flat-file install, which is the copy
+// that can be written to. A package that is not a junction stays where it is.
+function xboxGameDir(packageRoot) {
+  let real = packageRoot;
+  // Only the native call resolves the path in one go. The JavaScript one
+  // walks it with lstat, and lstat on `WindowsApps` itself is EPERM for
+  // anyone but an administrator, so on Node 20 it fails outright.
+  for (const resolve of [(p) => fs.realpathSync.native(p), (p) => fs.realpathSync(p)]) {
+    try { real = resolve(packageRoot); break; } catch { /* try the next one */ }
+  }
+  if (path.basename(real).toLowerCase() === 'content') {
+    const parent = path.dirname(real);
+    if (isXboxGameFolder(parent)) return parent;
+  }
+  return real;
+}
+
+function xbox(options = {}) {
+  const found = new Map();
+  const byIdentity = new Map();
+
+  const add = (dir, id) => {
+    const resolved = path.resolve(dir);
+    const key = resolved.toLowerCase();
+    const identity = (xboxIdentity(resolved) || '').toLowerCase();
+    const already = found.get(key) || (identity ? byIdentity.get(identity) : null);
+    if (already) {
+      // Reached twice; only the registry route knows the package name.
+      if (id && !already.id) already.id = id;
+      return;
+    }
+    const folderName = path.basename(resolved);
+    const name = xboxDisplayName(resolved) ||
+      (PACKAGE_FOLDER.test(folderName) ? nameFromPackage(folderName) : folderName);
+    if (NOT_A_GAME.test(name)) return;
+    const game = { launcher: 'Xbox', id: id || null, name, dir: resolved, poster: null };
+    found.set(key, game);
+    if (identity) byIdentity.set(identity, game);
+  };
+
+  // The sweep goes first: it lands on the flat-file install, the copy that can
+  // be written to. Its drive list is Windows-only, and asking for it anywhere
+  // else would pay for the PowerShell fallback inside drives().
+  const roots = options.drives || (process.platform === 'win32' ? drives() : []);
+  for (const drive of roots) {
+    const root = gamingRootFolder(drive);
+    if (!root) continue;
+    let entries = [];
+    try { entries = fs.readdirSync(root, { withFileTypes: true }); } catch { continue; }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || NOT_A_GAME_DIR.test(entry.name)) continue;
+      const dir = path.join(root, entry.name);
+      if (isXboxGameFolder(dir)) add(dir);
+    }
+  }
+
+  for (const packageRoot of xboxPackageRoots()) {
+    add(xboxGameDir(packageRoot), path.basename(packageRoot));
+  }
+  return [...found.values()];
+}
+
 // One game can be installed twice - a launcher copy and a loose copy. They are
 // different installs, so both are kept; only the exact same folder is merged.
 function dedupe(games) {
@@ -316,7 +471,7 @@ function filterExcluded(games, excludedRoots = []) {
 }
 
 function discover(extraFolders = [], scanDrives = false, excludedRoots = [], findAutoRoots = autoRoots) {
-  const found = [...steam(), ...epic(), ...gog(), ...ubisoft()];
+  const found = [...steam(), ...epic(), ...gog(), ...ubisoft(), ...xbox()];
   const roots = (scanDrives ? findAutoRoots() : [])
     .filter((root) => !excludedRoots.some((excluded) => isInside(root, excluded)));
   for (const dir of roots) found.push(...folder(dir, 'My folders', true));
@@ -327,4 +482,7 @@ function discover(extraFolders = [], scanDrives = false, excludedRoots = [], fin
   return { games: dedupe(filterExcluded(found, excludedRoots)), roots };
 }
 
-module.exports = { discover, folder, dedupe, autoRoots, drives, isInside, filterExcluded, steam, linuxSteamRoots, gog, ubisoft, setRegistryRunner };
+module.exports = {
+  discover, folder, dedupe, autoRoots, drives, isInside, filterExcluded,
+  steam, linuxSteamRoots, gog, ubisoft, xbox, gamingRootFolder, setRegistryRunner
+};

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -8,7 +8,7 @@ const state = { games: [], recents: [], history: [], newDlss: null, log: [], the
 const filters = { query: '', api: 'all', dlss: 'all', addon: 'all' };
 const gameFilters = window.gameFilters;
 
-const ORDER = ['Steam', 'Epic Games', 'GOG', 'Added by hand', 'My folders'];
+const ORDER = ['Steam', 'Epic Games', 'GOG', 'Xbox', 'Ubisoft', 'Added by hand', 'My folders'];
 const rank = (l) => (ORDER.indexOf(l) === -1 ? ORDER.length : ORDER.indexOf(l));
 const short = (v) => (v ? String(v).replace(/\.0$/, '') : null);
 const initials = (name) =>

--- a/test/library-xbox.test.js
+++ b/test/library-xbox.test.js
@@ -1,0 +1,179 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const library = require('../src/library.js');
+
+function tempRoot(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-xbox-library-'));
+  t.after(() => { library.setRegistryRunner(undefined); fs.rmSync(root, { recursive: true, force: true }); });
+  return root;
+}
+
+// What the Xbox app drops at the root of every drive it installs to: "RGBX",
+// a version, then the games folder as UTF-16 with a terminating null.
+function gamingRootMarker(relative) {
+  return Buffer.concat([
+    Buffer.from([0x52, 0x47, 0x42, 0x58, 0x01, 0x00, 0x00, 0x00]),
+    Buffer.from(relative + '\0', 'utf16le')
+  ]);
+}
+
+function config(displayName, identity) {
+  return [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    '<Game configVersion="1">',
+    '  <Identity',
+    `    Name="${identity || 'Publisher.' + displayName.replace(/[^A-Za-z0-9]/g, '')}"`,
+    '    Publisher="CN=00000000-0000-0000-0000-000000000000" />',
+    '  <ShellVisuals',
+    `    DefaultDisplayName="${displayName}"`,
+    '    StoreLogo="StoreLogo.png" />',
+    '  <ExecutableList>',
+    '    <Executable Name="game.exe" Id="Game" Architecture="x64"/>',
+    '  </ExecutableList>',
+    '</Game>'
+  ].join('\r\n');
+}
+
+// One game the way the app lays it out: <root>\<Game>\Content\.
+function installGame(root, folderName, displayName, identity) {
+  const content = path.join(root, folderName, 'Content');
+  fs.mkdirSync(content, { recursive: true });
+  fs.writeFileSync(path.join(content, 'MicrosoftGame.config'), config(displayName, identity));
+  fs.writeFileSync(path.join(content, 'game.exe'), 'test');
+  return path.join(root, folderName);
+}
+
+// Gaming Services' package repository, as `reg query ... /s /v Root` answers
+// it: one block per package, the folder written as an extended-length path.
+function fakeRegistry(packages) {
+  const repository = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\GamingServices\\PackageRepository\\Root';
+  return (args) => {
+    const [, queried, recurse, flag, value] = args;
+    // reg.exe takes the short root and answers with the long one.
+    const key = queried.replace(/^HKLM\\/, 'HKEY_LOCAL_MACHINE\\');
+    if (key !== repository || recurse !== '/s' || flag !== '/v' || value !== 'Root') {
+      throw new Error('ERROR: The system was unable to find the specified registry key or value.');
+    }
+    return Object.entries(packages).map(([family, dir]) =>
+      `\r\n${repository}\\${family}\\leaf\r\n    Root    REG_SZ    \\\\?\\${dir}\\\r\n`).join('') + '\r\n';
+  };
+}
+
+test('games in the folder named by .GamingRoot are found, and save data is not', (t) => {
+  const drive = tempRoot(t);
+  library.setRegistryRunner(() => { throw new Error('ERROR: no Gaming Services'); });
+
+  const root = path.join(drive, 'XboxGames');
+  const dave = installGame(root, 'Dave The Diver', 'Dave The Diver');
+  // Windows forbids a colon in a folder name, so the app strips it out. The
+  // config beside the game still has the title the store shows.
+  const heroes = installGame(root, 'Heroes of Might and Magic- Olden Era', 'Heroes of Might and Magic: Olden Era');
+  // Save data sits beside the games and has no Content folder.
+  fs.mkdirSync(path.join(root, 'GameSave', 'wgs'), { recursive: true });
+  fs.writeFileSync(path.join(drive, '.GamingRoot'), gamingRootMarker('XboxGames'));
+
+  const games = library.xbox({ drives: [drive] });
+  assert.equal(games.length, 2, 'both games, and nothing else in the folder');
+  assert.ok(games.every((g) => g.launcher === 'Xbox'));
+
+  const byDir = new Map(games.map((g) => [g.dir, g]));
+  assert.ok(byDir.has(dave), 'the game folder is the entry, not its Content');
+  assert.equal(byDir.get(dave).name, 'Dave The Diver');
+  assert.equal(byDir.get(heroes).name, 'Heroes of Might and Magic: Olden Era',
+    'the real title beats the folder name Windows allowed');
+});
+
+test('a drive with no marker, or a marker naming a folder that is gone, finds nothing', (t) => {
+  const drive = tempRoot(t);
+  library.setRegistryRunner(() => { throw new Error('ERROR: no Gaming Services'); });
+
+  assert.deepEqual(library.xbox({ drives: [drive] }), [], 'no marker at all');
+  assert.equal(library.gamingRootFolder(drive), null);
+
+  fs.writeFileSync(path.join(drive, '.GamingRoot'), gamingRootMarker('XboxGames'));
+  assert.deepEqual(library.xbox({ drives: [drive] }), [], 'the folder the marker names is gone');
+  assert.equal(library.gamingRootFolder(drive), null);
+
+  // Something else that happens to sit at that name is not a marker.
+  fs.writeFileSync(path.join(drive, '.GamingRoot'), 'not a marker');
+  assert.equal(library.gamingRootFolder(drive), null);
+});
+
+test('a package recorded in WindowsApps is followed back to the writable install', (t) => {
+  const root = tempRoot(t);
+  const drive = path.join(root, 'drive');
+  const gamesFolder = path.join(drive, 'XboxGames');
+  const game = installGame(gamesFolder, 'Dave The Diver', 'Dave The Diver');
+  fs.writeFileSync(path.join(drive, '.GamingRoot'), gamingRootMarker('XboxGames'));
+
+  // WindowsApps holds a junction back into the flat-file install, which is
+  // what the repository records.
+  const windowsApps = path.join(root, 'WindowsApps');
+  fs.mkdirSync(windowsApps, { recursive: true });
+  const pkg = 'Mintrocket.DaveTheDiver_1.0.145.0_x64__mnyz31d5jqk06';
+  fs.symlinkSync(path.join(game, 'Content'), path.join(windowsApps, pkg), 'junction');
+  library.setRegistryRunner(fakeRegistry({ '{A89ECE52}#{CAC205A6}': path.join(windowsApps, pkg) }));
+
+  const games = library.xbox({ drives: [drive] });
+  assert.equal(games.length, 1, 'the same install is not listed twice');
+  assert.equal(games[0].dir, game, 'the writable folder, not the protected package');
+  assert.equal(games[0].id, pkg, 'the package name is kept');
+  assert.equal(games[0].name, 'Dave The Diver');
+});
+
+// What the app actually did: on the Node that Electron bundles, resolving the
+// junction throws EPERM, because lstat on `Program Files\WindowsApps` itself
+// is refused to anyone who is not an administrator. Both routes then reach the
+// same game by paths that do not match, and it was listed twice.
+test('a game whose junction cannot be followed is still listed once', (t) => {
+  const root = tempRoot(t);
+  const drive = path.join(root, 'drive');
+  const game = installGame(path.join(drive, 'XboxGames'), 'Dave The Diver',
+    'Dave The Diver', 'Mintrocket.DaveTheDiver');
+  fs.writeFileSync(path.join(drive, '.GamingRoot'), gamingRootMarker('XboxGames'));
+
+  // A stand-in for the package the repository points at, which here cannot be
+  // resolved back to the folder above - exactly what EPERM leaves behind.
+  const windowsApps = path.join(root, 'WindowsApps');
+  const pkg = 'Mintrocket.DaveTheDiver_1.0.145.0_x64__mnyz31d5jqk06';
+  fs.mkdirSync(path.join(windowsApps, pkg), { recursive: true });
+  fs.writeFileSync(path.join(windowsApps, pkg, 'MicrosoftGame.config'),
+    config('Dave The Diver', 'Mintrocket.DaveTheDiver'));
+  fs.writeFileSync(path.join(windowsApps, pkg, 'game.exe'), 'test');
+  library.setRegistryRunner(fakeRegistry({ '{A89ECE52}#{CAC205A6}': path.join(windowsApps, pkg) }));
+
+  const games = library.xbox({ drives: [drive] });
+  assert.equal(games.length, 1, 'one game, not one per path it can be reached by');
+  assert.equal(games[0].dir, game, 'the writable copy wins over the protected one');
+  assert.equal(games[0].id, pkg, 'and it still picks up the package name');
+});
+
+test('a package that is not a junction is still listed, named from its package', (t) => {
+  const root = tempRoot(t);
+  const windowsApps = path.join(root, 'WindowsApps');
+  const pkg = 'Mintrocket.DaveTheDiver_1.0.145.0_x64__mnyz31d5jqk06';
+  fs.mkdirSync(path.join(windowsApps, pkg), { recursive: true });
+  fs.writeFileSync(path.join(windowsApps, pkg, 'game.exe'), 'test');
+  library.setRegistryRunner(fakeRegistry({
+    '{A89ECE52}#{CAC205A6}': path.join(windowsApps, pkg),
+    // A key left behind after the package was removed.
+    '{A89ECE52}#{DEADBEEF}': path.join(windowsApps, 'Gone.Package_1.0.0.0_x64__abcdefghijklm')
+  }));
+
+  const games = library.xbox({ drives: [] });
+  assert.equal(games.length, 1, 'only the package still on disk');
+  assert.equal(games[0].dir, path.join(windowsApps, pkg));
+  assert.equal(games[0].name, 'Dave The Diver', 'the package name read as words');
+});
+
+test('no Xbox install means no games and no error', (t) => {
+  const drive = tempRoot(t);
+  library.setRegistryRunner(() => { throw new Error('ERROR: The system was unable to find the specified registry key or value.'); });
+  assert.deepEqual(library.xbox({ drives: [drive] }), []);
+});


### PR DESCRIPTION
Closes the gap left by #188. Xbox games are detected once the scanner is
pointed at them, but nothing points at them: `XboxGames` is recognised as a
library root only by the drive sweep, and that is off by default. Steam, Epic,
GOG and Ubisoft need no sweep because each records where its library is. The
Xbox app records that too, in two places, and neither was read.

Every drive the app installs to carries a `.GamingRoot` marker naming that
drive's games folder, usually `XboxGames`, whose children hold their files a
level down in `Content` - the flat-file layout `scanGame` already understands.
Gaming Services also records each package under `PackageRepository\Root`,
pointing into `WindowsApps`, which finds a game whose drive marker has gone
missing. That repository is read with one recursive `reg` query rather than a
walk down its two key levels: 13 processes to 1, 389ms to 46ms.

On the five Game Pass installs here, every `WindowsApps` entry is a junction
into `XboxGames\<game>\Content`, so following it reaches the writable copy and
nothing has to be moved or reinstalled - no ownership is taken and no
permissions are changed. A package genuinely installed only into `WindowsApps`
is still listed and still reports as protected, exactly as before.

Both routes therefore reach one game by two paths, and they are matched on the
package identity out of `MicrosoftGame.config` rather than on the path itself.
That matters more than it looks: `fs.realpathSync` walks a path a component at
a time with `lstat`, and `lstat` on `Program Files\WindowsApps` is EPERM for
anyone but an administrator, so under the Node that Electron 33 bundles it
fails and every game gets listed twice - once behind each of its two paths.
`realpathSync.native` resolves it in one call and is tried first, but the
identity match is what makes the result independent of whether that worked.

The display name comes from `MicrosoftGame.config`, so the folder name Windows
allowed - `Heroes of Might and Magic- Olden Era` - is listed under the title
the store shows. Entries are grouped as "Xbox" rather than "My folders".

Verified on FINAL FANTASY VII REBIRTH DEMO in `C:\XboxGames` with drive
scanning off: discovered, scanned to
`Content\End\Binaries\WinGDK\ff7rebirth.exe` (DirectX 11/12, 64-bit), 48 files
installed via the Feeder route, played with DLSS 5, then restored with the
game's own files untouched. All five titles here are found and scan to an
installable executable. 146 tests pass, six of them new in
`test/library-xbox.test.js` covering the marker format, a missing or corrupt
marker, junction resolution, an unfollowable junction, a `WindowsApps`-only
package, and no Xbox install at all.
