### PR TITLE
Install the overlay for protected Xbox executables

### DIFF
--- a/src/game-overlay.js
+++ b/src/game-overlay.js
@@ -17,7 +17,7 @@ function prepare({library,target,route}){
   return {entry,file,alreadyPresent:fs.existsSync(file)};
 }
 async function attach({library,target,gameDir,manifest,saveManifest,plan}){
-  const installed=library.install('builtin',target.path);
+  const installed=library.install('builtin',target.path,target.bitness);
   // Only files newly added by THIS game install belong to Restore originals.
   const rel=path.relative(gameDir,installed.file);
   if(rel.startsWith('..')||path.isAbsolute(rel))throw Error('Overlay escaped the selected game.');

--- a/src/overlays.js
+++ b/src/overlays.js
@@ -119,12 +119,17 @@ function createOverlayLibrary(root, builtinFile, forbiddenRoots = []) {
     fs.unlinkSync(entry.file);
     fs.unlinkSync(path.join(entries, `${id}.json`));
   }
-  function install(id, exe) {
+  function install(id, exe, knownArchitecture = null) {
     const entry = resolve(id);
     if (!entry.ready) throw Error('Build the overlay add-on first.');
     const binary = readNative(entry.file);
-    const targetExe = readNative(exe, false);
-    if (binary.architecture !== targetExe.architecture) throw Error('Overlay and executable architectures do not match.');
+    const targetStat = fs.lstatSync(exe);
+    if (!targetStat.isFile() || targetStat.isSymbolicLink()) throw Error('Expected a regular Windows executable.');
+    const targetArchitecture = knownArchitecture === null
+      ? readNative(exe, false).architecture
+      : knownArchitecture;
+    if (![32, 64].includes(targetArchitecture)) throw Error('Invalid executable architecture.');
+    if (binary.architecture !== targetArchitecture) throw Error('Overlay and executable architectures do not match.');
     const targetDir = fs.realpathSync(path.dirname(exe));
     for (const forbidden of forbiddenRoots) if (inside(path.resolve(forbidden), targetDir)) throw Error('The main app and toolchain directories cannot be overlay targets.');
     if (list().installations.some(record => record.overlayId === id && record.directory.toLowerCase() === targetDir.toLowerCase() && record.sha256 !== binary.sha256)) throw Error('Remove the previous test overlay before installing a new build.');

--- a/test/overlay-update.test.js
+++ b/test/overlay-update.test.js
@@ -95,3 +95,27 @@ test('another game keeps its overlay when this one is updated', (t) => {
   assert.ok(fs.existsSync(untouched.file), 'only the game being installed into is updated');
   assert.deepEqual(library(newBuild).list().installations.map(r => r.directory), [second]);
 });
+
+test('a protected Xbox executable uses the architecture found by the game scanner', async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dlss5-overlay-xbox-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const gameDir = realDir(root, 'XboxGame', 'Content');
+  const exe = path.join(gameDir, 'Game.exe');
+  fs.writeFileSync(exe, 'encrypted executable placeholder');
+  const build = minimalPe(path.join(root, 'build', 'overlay.addon64'), { dll: true, filler: 2 });
+  const library = createOverlayLibrary(path.join(root, 'library'), build);
+  const target = { path: exe, bitness: 64, api: 'dxgi', apiLabel: 'DirectX 12' };
+  const plan = gameOverlay.prepare({ library, target, route: 'native' });
+  const manifest = { added: [] };
+
+  assert.throws(() => library.install('builtin', exe), /Invalid Windows PE binary/);
+  const installed = await gameOverlay.attach({
+    library, target, gameDir, manifest, plan,
+    saveManifest: async () => {}
+  });
+
+  assert.equal(fs.existsSync(installed.file), true);
+  assert.deepEqual(manifest.added, [path.basename(installed.file)]);
+  assert.equal(manifest.labOverlay.architecture, 64);
+});


### PR DESCRIPTION
## Problem

Some Xbox games expose enough metadata for the scanner and DLSS installation, but deny direct reads of their executable. The bundled overlay reopened that executable to determine its architecture, hit `EPERM`, and was skipped even though the main installation completed.

## Fix

Use the executable architecture already established by the game scanner when the bundled overlay is attached during a normal game installation. The manual Overlay-page installer still opens and validates executables selected by the user.

## Validation

- Full test suite passes: 141 tests
- Added a regression test for an unreadable Xbox executable
- Confirmed the F8 overlay connects and renders in an Xbox game

![DLSS 5 Swapper overlay connected in an Xbox game](https://raw.githubusercontent.com/BillyMRX1/DLSS5-Swapper/939888bb755cbdb06000b9dccaf1c607563ca177/docs/pr-evidence/xbox-overlay-protected-executable.png)

Closes #201
