### PR TITLE
Give release users useful missing-payload guidance

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@ const installRoutes = require('./src/shared/install-routes');
 const renderingApi = require('./src/shared/rendering-api');
 const { projectUrl } = require('./src/core/project-links');
 const optiscaler = require('./src/core/optiscaler');
+const { missingPayload } = require('./src/core/payload-guidance');
 const backends = require('./src/core/backend-manager');
 const journal = require('./src/core/file-journal');
 const guards = require('./src/core/install-guards');
@@ -1176,7 +1177,11 @@ async function exclusiveMutation(work) {
 
 ipcMain.handle('install', (event, dir, exePath, requestedRoute, requestedApi) => exclusiveMutation(async () => {
   const p = payload();
-  if (!p) return { ok: false, message: 'No payload found - run "npm run payload" in app/' };
+  if (!p) return { ok: false, ...missingPayload({
+    packaged: app.isPackaged,
+    resourcesPath: process.resourcesPath || __dirname,
+    appRoot: __dirname
+  }) };
   const scan = await scanGame(dir);
   if (!scan.chosen) return { ok: false, message: 'No game executable found' };
 

--- a/src/core/payload-guidance.js
+++ b/src/core/payload-guidance.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const path = require('node:path');
+
+function missingPayload({ packaged, resourcesPath, appRoot }) {
+  const directory = path.join(packaged ? resourcesPath : appRoot, 'payload');
+  if (!packaged) {
+    return {
+      code: 'errPayloadMissing',
+      message: `The payload is missing or incomplete at ${directory}. Run "npm run payload" from the project directory.`
+    };
+  }
+  return {
+    code: 'errPayloadMissing',
+    message: `Required DLSS files are missing or incomplete at ${directory}. Check antivirus quarantine, then restore and allow the files or reinstall DLSS 5 Swapper. No game files were changed.`
+  };
+}
+
+module.exports = { missingPayload };

--- a/test/payload-guidance.test.js
+++ b/test/payload-guidance.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { missingPayload } = require('../src/core/payload-guidance');
+
+test('an installed app gives recovery guidance when its payload is missing', () => {
+  const result = missingPayload({
+    packaged: true,
+    resourcesPath: path.join('C:', 'Program Files', 'DLSS 5 Swapper', 'resources'),
+    appRoot: path.join('C:', 'source')
+  });
+
+  assert.equal(result.code, 'errPayloadMissing');
+  assert.match(result.message, /resources[\\/]payload/);
+  assert.match(result.message, /antivirus quarantine/i);
+  assert.match(result.message, /reinstall DLSS 5 Swapper/i);
+  assert.match(result.message, /No game files were changed/i);
+  assert.doesNotMatch(result.message, /npm run payload/i);
+});
+
+test('a source checkout keeps the payload build command', () => {
+  const result = missingPayload({
+    packaged: false,
+    resourcesPath: path.join('C:', 'installed', 'resources'),
+    appRoot: path.join('C:', 'source')
+  });
+
+  assert.equal(result.code, 'errPayloadMissing');
+  assert.match(result.message, /source[\\/]payload/);
+  assert.match(result.message, /npm run payload/i);
+  assert.doesNotMatch(result.message, /reinstall DLSS 5 Swapper/i);
+});


### PR DESCRIPTION
## Problem

When the packaged app cannot find a complete payload, installation stops safely but tells the user to run `npm run payload`. That command only applies to a source checkout and gives release users no way to recover.

## Fix

Return guidance appropriate to the running build:

- Packaged builds name the expected payload directory, suggest checking antivirus quarantine or reinstalling the app, and confirm that no game files changed.
- Source checkouts retain the `npm run payload` instruction and name the local payload directory.

The check remains before game scanning and installation.

## Validation

- Full test suite passes: 163 tests
- Added coverage for packaged and source-checkout messages

Addresses #220
